### PR TITLE
Fix command location typo

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -53,7 +53,7 @@ fi
 function sail_is_not_running {
     echo -e "${WHITE}Sail is not running.${NC}"
     echo ""
-    echo -e "${WHITE}You may Sail using the following commands:${NC} './sail up' or './sail up -d'"
+    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'"
 
     exit 1
 }


### PR DESCRIPTION
Simple fix for command location. I assume it's a typo.