### PR TITLE
Use `DB_PORT` instead of `MYSQL_PORT` in `sail` bin

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -19,7 +19,7 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
-export MYSQL_PORT=${MYSQL_PORT:-3306}
+export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 


### PR DESCRIPTION
## The Issue

The `sail` command is listening to `MYSQL_PORT` but Sail uses `DB_PORT`.

## Explanation

`docker-compose` reads env vars from `.env` files (by coincidence), so `DB_PORT` mostly works based on settings in `.env`.

However, in `docker-compose`, env vars set as system env vars over-ride that (much like how DotEnv works)

So, if you want to over-write certain setting, the `sail` command allows that:

```bash
export APP_PORT=${APP_PORT:-80}
export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
export MYSQL_PORT=${MYSQL_PORT:-3306}
export WWWUSER=${WWWUSER:-$UID}
export WWWGROUP=${WWWGROUP:-$(id -g)}
```

That exports env vars for `docker-compose` to use, using either the value of the env var if already set, or defaulting to a sane value.

So you can do things like:

```bash
APP_PORT=8888 sail up -d
```

So, `sail` uses `DB_PORT`, but the `sail` command is looking for `MYSQL_PORT`, which I believe is a bug.

This fixes that so the `sail` command uses `DB_PORT`.

```bash
export APP_PORT=${APP_PORT:-80}
export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
export DB_PORT=${DB_PORT:-3306}
export WWWUSER=${WWWUSER:-$UID}
export WWWGROUP=${WWWGROUP:-$(id -g)}
```

So you can then run:

```bash
DB_PORT=33060 sail up -d
```