### PR TITLE
fix: fix warning of gnupg

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -14,6 +14,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update \
     && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin \
     && mkdir -p ~/.gnupg \
+    && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -14,6 +14,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN apt-get update \
     && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin \
     && mkdir -p ~/.gnupg \
+    && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \


### PR DESCRIPTION
gnupg will check the permissions of keys directory. 

if the permission not `600`, it will show a warning like `WARNING: unsafe permissions on homedir`


## Reference
https://lists.gnupg.org/pipermail/gnupg-users/2003-October/020342.html


## Screenshots
![](https://user-images.githubusercontent.com/13283837/101905403-5e96d600-3bf2-11eb-8c30-724c4423233f.png)

