### PR TITLE
Fix artisan schema:dump command in Sail environment 

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_15.x | bash - \
     && apt-get install -y nodejs \
+    && apt-get install -y mysql-client \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_15.x | bash - \
     && apt-get install -y nodejs \
+    && apt-get install -y mysql-client \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Description
`sail artisan schema:dump` is not working on a fresh Laravel project using Sail. That's because the `mysqldump` command is not found. This can be fixed with this PR, that's installing `mysql-client`. However, I am not sure if `mysql-client` was left out on purpose so I won't expect this to be merged. I know I can do this myself by exposing the Docker folder but I was just curious to read other opinions.

## How to test

- Install fresh project with sail
- run `sail artisan schema:dump`
- verify error about `mysqldump`

- Install fork
- `sail build --no-cache`
- `sail up`
- run `sail artisan schema:dump` and verify it's working as expected

## Screenshots
<img width="915" alt="Screenshot 2020-12-11 at 19 11 11" src="https://user-images.githubusercontent.com/14276144/101939028-aadb1980-3be4-11eb-94f8-2758b003818e.png">

