### PR TITLE
[1.x] Added python2 and libpng-dev to both runtime Dockerfile contents

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -11,8 +11,12 @@ ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ bionic universe" > /etc/apt/sources.list.d/universe.list \
+    && apt-get update \
+    && apt-get install -y python2
+
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \

--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -11,12 +11,8 @@ ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ bionic universe" > /etc/apt/sources.list.d/universe.list \
-    && apt-get update \
-    && apt-get install -y python2
-
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -11,8 +11,12 @@ ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN echo "deb http://archive.ubuntu.com/ubuntu/ bionic universe" > /etc/apt/sources.list.d/universe.list \
+    && apt-get update \
+    && apt-get install -y python2
+
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -11,12 +11,8 @@ ENV TZ=UTC
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu/ bionic universe" > /etc/apt/sources.list.d/universe.list \
-    && apt-get update \
-    && apt-get install -y python2
-
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \


### PR DESCRIPTION
### Description

This fixes two dependency issues which cause errors when running the command in Nova to create a new tool, eg:

`sail artisan nova:tool acme/price-tracker`

Python3 is installed by default in Ubuntu 20.04 (used by the Dockerfiles), but Python2 was required during the installation step of creating the Nova tool, as was libpng-dev, so these have been added to the Dockerfiles.

You might not want to accept this PR as it's very specific to Nova, but if not then maybe this info will help someone else who gets stuck like I did.

### How to test

- Install fresh Laravel project with Sail and Nova
- Try to create a new Nova tool as above, which will result in an error without this PR

### Screenshots

**Python2 dependency error:**

![Screenshot 2020-12-14 at 16 53 21](https://user-images.githubusercontent.com/2348955/102110453-144d6900-3e2d-11eb-9094-4bfb6a5df5ab.png)
![Screenshot 2020-12-14 at 16 53 40](https://user-images.githubusercontent.com/2348955/102110462-17485980-3e2d-11eb-94ed-f89c5cb3fe7b.png)

**Libpng-dev dependency error:**

![Screenshot 2020-12-14 at 17 06 34](https://user-images.githubusercontent.com/2348955/102111812-c0438400-3e2e-11eb-8890-b5dae6e832a1.png)
