### PR TITLE
Allow sail to run npx directly

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -170,6 +170,19 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy NPX commands to the "npx" binary on the application container...
+    elif [ "$1" == "npx" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                npx "$@"
+        else
+            sail_is_not_running
+        fi
+
     # Initiate a MySQL CLI terminal session within the "mysql" container...
     elif [ "$1" == "mysql" ]; then
         shift 1


### PR DESCRIPTION
I'm not sure this is exactly necessary, but I think it would be a nice addition, and would allow a better integration between sail and node. I'm currently doing `sail shell` and running npx from within the container, which doesn't feel as streamlined.

Just a thought.
