### PR TITLE
Fix mysql proxy variables

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -190,7 +190,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 mysql \
-                bash -c "MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u root ${MYSQL_DATABASE}"
+                bash -c 'MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u root ${MYSQL_DATABASE}'
         else
             sail_is_not_running
         fi

--- a/bin/sail
+++ b/bin/sail
@@ -190,7 +190,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 mysql \
-                bash -c 'MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u root ${MYSQL_DATABASE}'
+                bash -c 'MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
             sail_is_not_running
         fi


### PR DESCRIPTION
Fix: sail mysql doesn't pass variables correctly to the bash
Fix: sail mysql always using root to connect even if mysql_user in .env isn't root