### PR TITLE
Add phpmyadmin to docker compose to view database without native GUI

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -64,6 +64,18 @@ services:
             - 8025:8025
         networks:
             - sail
+    # phpmyadmin:
+    #     image: phpmyadmin/phpmyadmin
+    #     restart: unless-stopped
+    #     environment:
+    #         PMA_HOST: mysql
+    #         PMA_USER: '${DB_USERNAME}'
+    #         PMA_PASSWORD: '${DB_PASSWORD}'
+    #         PMA_PORT: 3306
+    #     ports:
+    #         - 8082:80
+    #     networks:
+    #         - sail
 networks:
     sail:
         driver: bridge


### PR DESCRIPTION
Adding phpmyadmin to as an option for the Sail docker-compose file. This helps uses using systems that may have difficult working with the docker networking connect and visualise the database as needed.

Due to dockers nature of IP's and routing can be difficult to find a quick way to connect to SQL clients. This will allow users to quickly uncomment `phpmyadmin` and simply run `sail up -d` and naviage to `localhost:8082` to visualise thier apps database.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
