### PR TITLE
[1.x] Fix for circular dependency error with selenium

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -27,8 +27,6 @@ services:
     #         - '/dev/shm:/dev/shm'
     #     networks:
     #         - sail
-    #     depends_on:
-    #         - laravel.test
     mysql:
         image: 'mysql:8.0'
         ports:


### PR DESCRIPTION
Avoid circular reference in between selenium and laravel.test

The error that is thrown when uncommenting all the lines is :

`ERROR: Circular dependency between laravel.test and selenium and redis`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
