### PR TITLE
add sail bash to Initiate a Bash shell within the application container

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -198,7 +198,7 @@ if [ $# -gt 0 ]; then
         fi
 
     # Initiate a Bash shell within the application container...
-    elif [ "$1" == "shell" ]; then
+    elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then


### PR DESCRIPTION
Adding sail bash to Initiate a bash shell within the application container like sail shell.
I caught myself typing sail bash more than one time instead of sail shell 