### PR TITLE
Docker Speed Improvements by caching the volumes of MySQL and Redis

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -38,7 +38,7 @@ services:
             MYSQL_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         volumes:
-            - 'sailmysql:/var/lib/mysql'
+            - 'sailmysql:/var/lib/mysql:cached'
         networks:
             - sail
     redis:
@@ -46,7 +46,7 @@ services:
         ports:
             - '${FORWARD_REDIS_PORT:-6379}:6379'
         volumes:
-            - 'sailredis:/data'
+            - 'sailredis:/data:cached'
         networks:
             - sail
     # memcached:


### PR DESCRIPTION
Docker Volumes are very resource heavy and uses a lot of system resources. implementing the caching on MySQL and Redis will improve the speed.

The idea came from a question asked on laracasts where I shared my experience.

https://laracasts.com/discuss/channels/laravel/laravel-sail-docker-is-too-slow-on-mac-optimization-possible

How cached works:
cached: the host’s view is authoritative
(permit delays before updates on the host appear in the container)

In the case of Mysql and Redis Images, We would never write directly to the MySQL and Redis storage files on the host machine. So "cached" cannot affect in a bad manner.

Ref:
http://docs.docker.oeynet.com/docker-for-mac/osxfs-caching/#tuning-with-consistent-cached-and-delegated-configurations

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
