### PR TITLE
[1.x] root-shell added to bin/sail

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -223,7 +223,7 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
-    # Initiate a root bash shell within the application container...
+    # Initiate a root user Bash shell within the application container...
     elif [ "$1" == "root-shell" ] ; then
         shift 1
 

--- a/bin/sail
+++ b/bin/sail
@@ -223,6 +223,18 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Initiate a root bash shell within the application container...
+    elif [ "$1" == "root-shell" ] ; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                "$APP_SERVICE" \
+                bash
+        else
+            sail_is_not_running
+        fi
+
     # Share the site...
     elif [ "$1" == "share" ]; then
         shift 1


### PR DESCRIPTION
Without looking into the base container image there is no documented way to know what is the root password and there is no sudo, so I've added a `root-shell` to `bin/sail`.

Other relevant options which solve the same issue: add `sudo` and add `sail` user to sudoers or document root password.