### PR TITLE
[1.x] Add healthcheck for mysql and redis service in docker-compose

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -41,6 +41,8 @@ services:
             - 'sailmysql:/var/lib/mysql'
         networks:
             - sail
+        healthcheck:
+          test: ["CMD", "mysqladmin", "ping"]
     redis:
         image: 'redis:alpine'
         ports:
@@ -49,6 +51,8 @@ services:
             - 'sailredis:/data'
         networks:
             - sail
+        healthcheck:
+          test: ["CMD", "redis-cli", "ping"]
     # memcached:
     #     image: 'memcached:alpine'
     #     ports:


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adding these healthchecks allows a user to check the availability and status of a container and allows docker-compose services to wait on services they depend on to be healthy before starting themselves. 