### PR TITLE
Add locales-all package

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 locales-all \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -12,7 +12,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 locales-all \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \


### PR DESCRIPTION
Our Laravel project has a requirement to convert non-english characters (such as é and ñ) and convert them to their English-only equivalents (é -> e, ñ -> n).

To do this, we use PHP's built-in [iconv](https://www.php.net/manual/en/function.iconv.php) function. For `iconv` to work however, the machine where the code is running needs to have the correct locales installed.

We did this on our server but locally Sail does not have any locales installed by default.

This PR installs the Ubuntu package [locales-all](https://packages.ubuntu.com/focal/locales-all) to Sail in order to configure every available locale to Ubuntu. This means all non-english characters will be supported locally in Sail when running PHP code. 

I have already done this locally using `sail:publish` and this fixes our `iconv` conversion. I thought it would be nice to have this as the default, so all locales are configured without thinking about it (it just works).
