### PR TITLE
[1.x] Append PostgreSQL HealthCheck

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -57,6 +57,8 @@ services:
 #            - 'sailpostgresql:/var/lib/postgresql/data'
 #        networks:
 #            - sail
+#        healthcheck:
+#          test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
     redis:
         image: 'redis:alpine'
         ports:


### PR DESCRIPTION
Adding these healthchecks allows a user to check the availability and status of a container and allows docker-compose services to wait on services they depend on to be healthy before starting themselves.