### PR TITLE
Add a MySQL test database to docker-compose.yml

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -44,6 +44,16 @@ services:
             - sail
         healthcheck:
           test: ["CMD", "mysqladmin", "ping"]
+#    mysql_test:
+#        image: 'mysql:8.0'
+#        environment:
+#            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+#            MYSQL_DATABASE: '${DB_DATABASE}'
+#            MYSQL_USER: '${DB_USERNAME}'
+#            MYSQL_PASSWORD: '${DB_PASSWORD}'
+#            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+#        networks:
+#            - sail
 #    pgsql:
 #        image: postgres:13
 #        ports:


### PR DESCRIPTION
It can be useful to use a second database for running tests such as Dusk tests. Adding this service to the `docker-compose.yml` file will make it easier to do this.

To use it, uncomment the `mysql_test` service in docker-compose.yml, and then add the following to your `.env.dusk.local` file:

```
DB_HOST=mysql_test
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
