### PR TITLE
Add support for dusk:fails

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -133,6 +133,21 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy the "dusk:fails" command to the "php artisan dusk:fails" Artisan command...
+    elif [ "$1" == "dusk:fails" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                -e "APP_URL=http://laravel.test" \
+                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
+                "$APP_SERVICE" \
+                php artisan dusk:fails "$@"
+        else
+            sail_is_not_running
+        fi
+
     # Initiate a Laravel Tinker session within the application container...
     elif [ "$1" == "tinker" ] ; then
         shift 1


### PR DESCRIPTION
This adds support for running `sail dusk:fails` as running `sail artisan dusk:fails` doesn't work properly.

If this is merged, I will add a PR adding usage instructions on the Laravel docs repository.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
