### PR TITLE
Make app service user configurable, as well as db service names

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -21,7 +21,10 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_USER=${APP_USER:-"sail"}
 export DB_PORT=${DB_PORT:-3306}
+export MYSQL_SERVICE=${MYSQL_SERVICE:-mysql}
+export PGSQL_SERVICE=${PGSQL_SERVICE:-pgsql}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 
@@ -72,7 +75,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php "$@"
         else
@@ -85,7 +88,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 composer "$@"
         else
@@ -98,7 +101,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan "$@"
         else
@@ -111,7 +114,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan test "$@"
         else
@@ -124,7 +127,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 -e "APP_URL=http://laravel.test" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -154,7 +157,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan tinker
         else
@@ -167,7 +170,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 node "$@"
         else
@@ -180,7 +183,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 npm "$@"
         else
@@ -193,7 +196,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 npx "$@"
         else
@@ -206,7 +209,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 yarn "$@"
         else
@@ -219,7 +222,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                mysql \
+                "$MYSQL_SERVICE" \
                 bash -c 'MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
             sail_is_not_running
@@ -231,7 +234,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                 pgsql \
+                 "$PGSQL_SERVICE" \
                  bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
             sail_is_not_running
@@ -243,7 +246,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 bash
         else

--- a/bin/sail
+++ b/bin/sail
@@ -23,8 +23,8 @@ export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
 export APP_USER=${APP_USER:-"sail"}
 export DB_PORT=${DB_PORT:-3306}
-export MYSQL_SERVICE=${MYSQL_SERVICE:-mysql}
-export PGSQL_SERVICE=${PGSQL_SERVICE:-pgsql}
+export MYSQL_SERVICE=${MYSQL_SERVICE:-"mysql"}
+export PGSQL_SERVICE=${PGSQL_SERVICE:-"pgsql"}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 


### PR DESCRIPTION
This PR will add the following env vars to be used in `bin/sail`:

- `APP_USER` (default 'sail')
- `MYSQL_SERVICE` (default 'mysql')
- `PGSQL_SERVICE` (default 'pgsql')

Context:

I work with an existing Docker Compose setup, which was created before Laravel Sail came out.

However, Sail is a great tool to wrap around docker-compose regardless, and this PR with minor, non-breaking changes will better support Docker Compose configurations with different DB service names and the username for the service where you run your CLI tools in.

In my case I use MariaDB (container named 'mariadb'), and I have a separate workspace container where I usually bash into (as user 'user') and run my commands from.