### PR TITLE
Use non-root MySQL password for `sail mysql`

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -220,7 +220,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 mysql \
-                bash -c 'MYSQL_PWD=${MYSQL_ROOT_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
             sail_is_not_running
         fi


### PR DESCRIPTION
This is a small yet separate addendum to my other PR: https://github.com/laravel/sail/pull/44

This PR changes the provided password for to the MySQL CLI on the `sail mysql` command from `MYSQL_ROOT_PASSWORD` to `MYSQL_PASSWORD`.

Context:

This is for custom Docker Compose setups from before Laravel Sail came out. Sail automatically sets the `MYSQL_ROOT_PASSWORD` env variable to `.env`'s DB_PASSWORD.

When working with a Docker Compose configuration that have separate passwords between the MySQL root user and the MySQL working (i.e. non-root) user, `sail mysql` will throw the classic 'Access denied for user X (using password: YES)' MySQL error.

One could also argue that the current call to the MySQL CLI is erroneous since it combines MYSQL_USER (not root) and MYSQL_ROOT_PASSWORD.

This PR fixes this by using MYSQL_PASSWORD instead, as mentioned above. Tested with a fresh Laravel installation to make sure it didn't break. 