### PR TITLE
make Sail:install publish the appropriate config file (mysql / pgsql) based on .env

### DIFF
--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -29,11 +29,18 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
     protected function registerCommands()
     {
         Artisan::command('sail:install', function () {
-            copy(__DIR__.'/../stubs/docker-compose.yml', base_path('docker-compose.yml'));
-
             $environment = file_get_contents(base_path('.env'));
 
-            $environment = str_replace('DB_HOST=127.0.0.1', 'DB_HOST=mysql', $environment);
+            if(str_contains($environment, 'DB_CONNECTION=pgsql')){
+                copy(__DIR__.'/../stubs/docker-compose-pgsql.yml', base_path('docker-compose.yml'));
+
+                $environment = str_replace('DB_HOST=127.0.0.1', 'DB_HOST=pgsql', $environment);
+            }else {
+                copy(__DIR__.'/../stubs/docker-compose-mysql.yml', base_path('docker-compose.yml'));
+
+                $environment = str_replace('DB_HOST=127.0.0.1', 'DB_HOST=mysql', $environment);
+            }
+
             $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
             $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);
 

--- a/stubs/docker-compose-mysql.yml
+++ b/stubs/docker-compose-mysql.yml
@@ -19,7 +19,6 @@ services:
             - sail
         depends_on:
             - mysql
-            # - pgsql
             - redis
             # - selenium
     # selenium:
@@ -44,21 +43,6 @@ services:
             - sail
         healthcheck:
           test: ["CMD", "mysqladmin", "ping"]
-#    pgsql:
-#        image: postgres:13
-#        ports:
-#            - '${FORWARD_DB_PORT:-5432}:5432'
-#        environment:
-#            PGPASSWORD: '${DB_PASSWORD:-secret}'
-#            POSTGRES_DB: '${DB_DATABASE}'
-#            POSTGRES_USER: '${DB_USERNAME}'
-#            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
-#        volumes:
-#            - 'sailpostgresql:/var/lib/postgresql/data'
-#        networks:
-#            - sail
-#        healthcheck:
-#          test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
     redis:
         image: 'redis:alpine'
         ports:
@@ -88,7 +72,5 @@ networks:
 volumes:
     sailmysql:
         driver: local
-#    sailpostgresql:
-#        driver: local
     sailredis:
         driver: local

--- a/stubs/docker-compose-pgsql.yml
+++ b/stubs/docker-compose-pgsql.yml
@@ -1,0 +1,76 @@
+# For more information: https://laravel.com/docs/sail
+version: '3'
+services:
+    laravel.test:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.0
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.0/app
+        ports:
+            - '${APP_PORT:-80}:80'
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        depends_on:
+            - pgsql
+            - redis
+            # - selenium
+    # selenium:
+    #     image: 'selenium/standalone-chrome'
+    #     volumes:
+    #         - '/dev/shm:/dev/shm'
+    #     networks:
+    #         - sail
+
+    pgsql:
+       image: postgres:13
+       ports:
+           - '${FORWARD_DB_PORT:-5432}:5432'
+       environment:
+           PGPASSWORD: '${DB_PASSWORD:-secret}'
+           POSTGRES_DB: '${DB_DATABASE}'
+           POSTGRES_USER: '${DB_USERNAME}'
+           POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+       volumes:
+           - 'sailpostgresql:/var/lib/postgresql/data'
+       networks:
+           - sail
+       healthcheck:
+         test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
+    redis:
+        image: 'redis:alpine'
+        ports:
+            - '${FORWARD_REDIS_PORT:-6379}:6379'
+        volumes:
+            - 'sailredis:/data'
+        networks:
+            - sail
+        healthcheck:
+          test: ["CMD", "redis-cli", "ping"]
+    # memcached:
+    #     image: 'memcached:alpine'
+    #     ports:
+    #         - '11211:11211'
+    #     networks:
+    #         - sail
+    mailhog:
+        image: 'mailhog/mailhog:latest'
+        ports:
+            - '${FORWARD_MAILHOG_PORT:-1025}:1025'
+            - '${FORWARD_MAILHOG_DASHBOARD_PORT:-8025}:8025'
+        networks:
+            - sail
+networks:
+    sail:
+        driver: bridge
+volumes:
+    sailpostgresql:
+       driver: local
+    sailredis:
+        driver: local


### PR DESCRIPTION
This is a small change to avoid commenting/uncommenting and make the published `docker-compose.yml` cleaner.
Maybe in the future, someone adds support to any type of database.
inspired by #28 's comments