### PR TITLE
[1.x] Optional Xdebug 3.0 support

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -40,6 +40,22 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ARG XDEBUG
+ARG XDEBUG_PORT
+RUN if [ "${XDEBUG}" = 'true' ]; then \
+    apt-get update \
+    && apt-get install -y php-xdebug \
+    && echo "[XDebug]" > /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini \
+    && echo "zend_extension="$(find /usr/lib/php/ -name xdebug.so | sort -z | head -n 1)" >> /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini" \
+    && echo "xdebug.client_port = ${XDEBUG_PORT}" >> /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.mode = debug" >> /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_host = host.docker.internal" >> /etc/php/7.4/cli/conf.d/php-ext-xdebug.ini \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ;\
+fi;
+
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php7.4
 
 RUN groupadd --force -g $WWWGROUP sail

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -40,6 +40,22 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ARG XDEBUG
+ARG XDEBUG_PORT
+RUN if [ "${XDEBUG}" = 'true' ]; then \
+    apt-get update \
+    && apt-get install -y php-xdebug \
+    && echo "[XDebug]" > /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "zend_extension="$(find /usr/lib/php/ -name xdebug.so | sort -z | head -n 1)" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini" \
+    && echo "xdebug.client_port = ${XDEBUG_PORT}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.mode = debug" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.start_with_request = yes" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_host = host.docker.internal" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ;\
+fi;
+
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 
 RUN groupadd --force -g $WWWGROUP sail

--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -12,6 +12,8 @@ services:
             - '${APP_PORT:-80}:80'
         environment:
             WWWUSER: '${WWWUSER}'
+            XDEBUG: '${SAIL_XDEBUG:-false}'
+            XDEBUG_PORT: '${SAIL_XDEBUG_PORT:-9000}'
             LARAVEL_SAIL: 1
         volumes:
             - '.:/var/www/html'


### PR DESCRIPTION
This pull request introduces Xdebug 3.0 support for both PHP 7.4 and 8.0.

The support is disabled by default and developers can be enable it by setting `SAIL_XDEBUG=true` in their .env file. They also have the ability to override the default Xdebug port (9000) by setting the`SAIL_XDEBUG_PORT` variable. 