### PR TITLE
[1.x] Pass DB_PASSWORD to mysql healthcheck

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -43,7 +43,7 @@ services:
         networks:
             - sail
         healthcheck:
-          test: ["CMD", "mysqladmin", "ping"]
+          test: ["CMD", "mysqladmin", "-p${DB_PASSWORD}", "ping"]
 #    pgsql:
 #        image: postgres:13
 #        ports:


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Without passing root password, mysql container healthcheck constantly outputs this message:

`mysql_1         | 2021-01-29 11:17:48 4 [Warning] Access denied for user 'root'@'localhost' (using password: NO)`

Tested on `mariadb:10.5` image as it is compatible with `mysql:8.0` (using same default `environment`)