### PR TITLE
Add PHPStan support to Sail

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -237,6 +237,19 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy PHPStan commands to the "phpstan" binary on the application container...
+    elif [ "$1" == "phpstan" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                "$APP_SERVICE" \
+                ./vendor/bin/phpstan "$@"
+        else
+            sail_is_not_running
+        fi
+
     # Initiate a Bash shell within the application container...
     elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
         shift 1


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR aims to add support for `phpstan` commands without accessing the application container, it behaves like all the commands that being proxied.

Usage:

```bash
sail phpstan analyse app tests
```

assuming that sail up and running!