### PR TITLE
Inform user when running docker-compose down

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -42,7 +42,7 @@ fi
 PSRESULT="$(docker-compose ps -q)"
 
 if docker-compose ps | grep 'Exit'; then
-    echo -e "${WHITE}Shutting down stale Sail processes...${NC}" >&2
+    echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
     docker-compose down > /dev/null 2>&1
 

--- a/bin/sail
+++ b/bin/sail
@@ -42,7 +42,8 @@ fi
 PSRESULT="$(docker-compose ps -q)"
 
 if docker-compose ps | grep 'Exit'; then
-    echo -e "${WHITE}Shutting down sail${NC}" >&2
+    echo -e "${WHITE}Shutting down stale Sail processes...${NC}" >&2
+
     docker-compose down > /dev/null 2>&1
 
     EXEC="no"

--- a/bin/sail
+++ b/bin/sail
@@ -41,7 +41,8 @@ fi
 # Determine if Sail is currently up...
 PSRESULT="$(docker-compose ps -q)"
 
-if docker-compose ps | grep 'Exit' &> /dev/null; then
+if docker-compose ps | grep 'Exit'; then
+    echo -e "${WHITE}Shutting down sail${NC}" >&2
     docker-compose down > /dev/null 2>&1
 
     EXEC="no"


### PR DESCRIPTION
Spent many hours scratching my head not realizing that a service I knew wasn't working yet was causing me to not be able to run sail art migrate which was needed by the failed service

This will now print out a message with the failed services and that it is shutting down

```
[philip@philip-xps laravel]$ sail shell
laravel_monitoring_1     laravel-monitoring               Exit 1                                          
Shutting down sail
Sail is not running.

You may Sail using the following commands: './vendor/bin/sail up' or './vendor/bin/sail up -d'
[philip@philip-xps laravel]$ 
```