### PR TITLE
Cleanup supervisord warnings on start

### DIFF
--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ];then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord
+    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ];then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord
+    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+user=root
 
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80


### PR DESCRIPTION
On start, supervisor throws up a couple warnings about implied configurations. The warnings are minor but since the corrections are simple it seems worthwhile. 

No changes are made to the actual functionality here. 