### PR TITLE
Load vars from .env file correctly

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -65,7 +65,7 @@ function sail_is_not_running {
 if [ $# -gt 0 ]; then
     # Source the ".env" file so Laravel's environment variables are available...
     if [ -f ./.env ]; then
-        source ./.env
+        export $(cat ./.env | xargs)
     fi
 
     # Proxy PHP commands to the "php" binary on the application container...


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

The `source` command won't work, because the env vars are not exported with `export`, which lead to e.g. the DB_PASSWORD being ignored. This change will load the env variables from the .env file correctly.
