### PR TITLE
Move to mariadb db image to support arm64 architecture.

### DIFF
--- a/stubs/docker-compose.yml
+++ b/stubs/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     #     networks:
     #         - sail
     mysql:
-        image: 'mysql:8.0'
+        image: 'mariadb:latest'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:


### PR DESCRIPTION
MySql Docker Official Image doesn't match manifest for linux/arm64 architecture so brand new Apple Mac M1 and other arm based systems are not supported within current Laravel Sail stack. Moving to mariadb by default will fix this issue.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
