### PR TITLE
[1.x] Change supervisord logfile and pidfile settings

### DIFF
--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -1,6 +1,8 @@
 [supervisord]
 nodaemon=true
 user=root
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -1,6 +1,8 @@
 [supervisord]
 nodaemon=true
 user=root
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80


### PR DESCRIPTION
The default value for `logfile` is `$CWD/supervisord.log` and for `pidfile` is `$CWD/supervisord.pid` [(supervisord section settings).](http://supervisord.org/configuration.html#supervisord-section-settings)
Those settings omitted in the current configuration. So supervisor creates `supervisord.log` and `supervisord.pid` in current working directory `/var/www/html`. That directory has been mounted to the user's filesystem, let's use the proper location.