### PR TITLE
Add php version to install command

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -11,7 +11,9 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'sail:install {--services= : The services that should be included in the installation}';
+    protected $signature = 'sail:install
+                            {--runtime= : The PHP runtime to use}
+                            {--services= : The services that should be included in the installation}';
 
     /**
      * The console command description.
@@ -76,16 +78,14 @@ class InstallCommand extends Command
      */
     protected function chooseRuntimeWithSymfonyMenu()
     {
-        $availableRuntimes = array_map(
+        $availableRuntimes = array_reverse(array_map(
             'basename',
             glob(__DIR__.'/../../runtimes/*', GLOB_ONLYDIR)
-        );
+        ));
         return $this->choice(
             'Which runtime would you like to use?',
             $availableRuntimes,
-            0,
-            null,
-            true
+            0
         );
     }
 

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -30,8 +30,8 @@ class PublishCommand extends Command
         $this->call('vendor:publish', ['--tag' => 'sail']);
 
         file_put_contents($this->laravel->basePath('docker-compose.yml'), str_replace(
-            './vendor/laravel/sail/runtimes/8.0',
-            './docker/8.0',
+            './vendor/laravel/sail/runtimes',
+            './docker',
             file_get_contents($this->laravel->basePath('docker-compose.yml'))
         ));
     }

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -3,11 +3,11 @@ version: '3'
 services:
     laravel.test:
         build:
-            context: ./vendor/laravel/sail/runtimes/8.0
+            context: ./vendor/laravel/sail/runtimes/{{runtime}}
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
-        image: sail-8.0/app
+        image: sail-{{runtime}}/app
         ports:
             - '${APP_PORT:-80}:80'
         environment:


### PR DESCRIPTION
Add option to select php runtime in install command.
The feature is presently commented out since the service selection feature is also disabled.
If that ever makes it back in then this would be a nice addition.