### PR TITLE
[1.x] Update publish command to also consider 7.4

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -30,8 +30,14 @@ class PublishCommand extends Command
         $this->call('vendor:publish', ['--tag' => 'sail']);
 
         file_put_contents($this->laravel->basePath('docker-compose.yml'), str_replace(
-            './vendor/laravel/sail/runtimes/8.0',
-            './docker/8.0',
+            [
+                './vendor/laravel/sail/runtimes/7.4',
+                './vendor/laravel/sail/runtimes/8.0',
+            ],
+            [
+                './docker/8.0',
+                './docker/7.4',
+            ],
             file_get_contents($this->laravel->basePath('docker-compose.yml'))
         ));
     }


### PR DESCRIPTION
The `sail:install` command was not updated for PHP 7.4

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
