### PR TITLE
Add missing PostgreSQL clients

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y yarn \
     && apt-get install -y mysql-client \
+    && apt-get install -y postgresql-client \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y yarn \
     && apt-get install -y mysql-client \
+    && apt-get install -y postgresql-client \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Because Laravel's new `schema:dump` functionality uses `pg_restore` to migrate, it needs to be available in the app container. Currently a project using schema dumps cannot migrate if it uses Sail.