### PR TITLE
[1.x] Make exec user configurable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -21,6 +21,7 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_USER=${APP_USER:-"sail"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
@@ -74,7 +75,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php "$@"
         else
@@ -87,7 +88,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 composer "$@"
         else
@@ -100,7 +101,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan "$@"
         else
@@ -113,7 +114,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan test "$@"
         else
@@ -126,7 +127,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 -e "APP_URL=http://laravel.test" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -141,7 +142,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 -e "APP_URL=http://laravel.test" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -156,7 +157,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 php artisan tinker
         else
@@ -169,7 +170,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 node "$@"
         else
@@ -182,7 +183,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 npm "$@"
         else
@@ -195,7 +196,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 npx "$@"
         else
@@ -208,7 +209,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 yarn "$@"
         else
@@ -245,7 +246,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail \
+                -u "$APP_USER" \
                 "$APP_SERVICE" \
                 bash
         else


### PR DESCRIPTION
Currently, the user that Docker commands are executed as is hard-coded to the `sail` user (`-u sail`).

This PR is a small, backwards-compatible change that allows changing this user through the `APP_USER` environment variable.

