### PR TITLE
[1.x] Add PgAdmin service

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -56,6 +56,7 @@ class InstallCommand extends Command
              'meilisearch',
              'mailhog',
              'selenium',
+             'pgadmin',
          ], 0, null, true);
     }
 

--- a/stubs/pgadmin.stub
+++ b/stubs/pgadmin.stub
@@ -1,0 +1,9 @@
+    pgadmin:
+        image: dpage/pgadmin4
+        ports:
+            - '5433:80'
+        environment:
+            PGADMIN_DEFAULT_EMAIL: pgadmin@pgadmin.com
+            PGADMIN_DEFAULT_PASSWORD: secret
+        networks:
+            - sail


### PR DESCRIPTION
I'm using VSCode editor and I always have to manually add this PgAdmin service to the docker-compose. It would be nice if it is already included. The user can choose whether or not to include it in their development environment. 