### PR TITLE
Update the publish command to consider PHP 7.4

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -29,10 +29,19 @@ class PublishCommand extends Command
     {
         $this->call('vendor:publish', ['--tag' => 'sail']);
 
-        file_put_contents($this->laravel->basePath('docker-compose.yml'), str_replace(
-            './vendor/laravel/sail/runtimes/8.0',
-            './docker/8.0',
-            file_get_contents($this->laravel->basePath('docker-compose.yml'))
-        ));
+        file_put_contents(
+            $this->laravel->basePath('docker-compose.yml'), 
+            str_replace(
+                [
+                    './vendor/laravel/sail/runtimes/8.0',
+                    './vendor/laravel/sail/runtimes/7.4',
+                ],
+                [
+                    './docker/8.0',
+                    './docker/7.4', 
+                ],
+                file_get_contents($this->laravel->basePath('docker-compose.yml'))
+            )
+        );
     }
 }


### PR DESCRIPTION
Currently, the publish command does not replace the PHP 7.4 runtime correctly, this fixes that.