### PR TITLE
[1.x] Use different DB user for Sail

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -117,8 +117,9 @@ class InstallCommand extends Command
             $environment = str_replace('DB_PORT=3306', "DB_PORT=5432", $environment);
         } else {
             $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mysql", $environment);
+            $environment = str_replace('DB_USERNAME=root', "DB_USERNAME=sail", $environment);
         }
-        
+
         $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
         $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -118,6 +118,7 @@ class InstallCommand extends Command
         } else {
             $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mysql", $environment);
             $environment = str_replace('DB_USERNAME=root', "DB_USERNAME=sail", $environment);
+            $environment = str_replace('DB_PASSWORD=', "DB_PASSWORD=password", $environment);
         }
 
         $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);


### PR DESCRIPTION
Needs a co-PR to the Sail container to add a sail user on "sail up".

Fixes https://github.com/laravel/sail/issues/70