### PR TITLE
Add Elasticsearch with Kibana option

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -54,6 +54,7 @@ class InstallCommand extends Command
              'redis',
              'memcached',
              'meilisearch',
+             'elasticsearch',
              'mailhog',
              'selenium',
          ], 0, null, true);
@@ -82,7 +83,7 @@ class InstallCommand extends Command
 
         $volumes = collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'redis', 'meilisearch']);
+                return in_array($service, ['mysql', 'pgsql', 'redis', 'meilisearch', 'elasticseach']);
             })->map(function ($service) {
                 return "    sail{$service}:\n        driver: local";
             })->whenNotEmpty(function ($collection) {

--- a/stubs/elasticsearch.stub
+++ b/stubs/elasticsearch.stub
@@ -1,0 +1,30 @@
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+        container_name: sailelastic
+        environment:
+            - node.name=es01
+            - cluster.name=es-docker-cluster
+            - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        volumes:
+            - sailelasticsearch:/usr/share/elasticsearch/data
+        ports:
+            - '${FORWARD_ELASTIC_PORT:-9200}:9200'
+        networks:
+            - sail
+
+    kibana:
+        image: docker.elastic.co/kibana/kibana:7.9.3
+        container_name: sailkibana
+        ports:
+            - '${FORWARD_KIBANA_PORT:-5601}:5601'
+        environment:
+            ELASTICSEARCH_URL: http://es01:9200
+            ELASTICSEARCH_HOSTS: http://es01:9200
+        networks:
+            - sail


### PR DESCRIPTION
This Pull Request adds the option to add an elastic with kibana service to the application's docker-compose.yml.
I could split elastic and kibana, but I think it is very likely that users would like the ease of use of having both added at the same time.

The configuration of the containers is copied from the [official Elastic docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html) on using it with Docker. The same configuration is also tested in an application using Elasticsearch as a Scout driver. Because such driver is a third-party package I have omitted setting the Scout driver in the .env.