### PR TITLE
[1.x] Patch issue with environment database password replacement

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -120,7 +120,7 @@ class InstallCommand extends Command
         }
 
         $environment = str_replace('DB_USERNAME=root', "DB_USERNAME=sail", $environment);
-        $environment = str_replace('DB_PASSWORD=', "DB_PASSWORD=password", $environment);
+        $environment = preg_replace("/DB_PASSWORD=(.*)/", "DB_PASSWORD=password", $environment);
 
         $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
         $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);


### PR DESCRIPTION
This update fixes an issue that is caused if you already have a DB_PASSWORD configured in your .env. Prior to this change, if you have this (for example):

```
DB_PASSWORD=mypassword
```

After running `sail:install` it would then look like this:

```
DB_PASSWORD=passwordmypassword
```

And each time you run `sail install` it'll keep growing. This is because only DB_PASSWORD= is being replaced, when it should be replacing the password as well, which can be accomplished using `preg_replace` and a simple regex as in this PR.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
