### PR TITLE
Load missing PECL package index before installing Swoole.

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -41,7 +41,8 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN pecl install swoole
+RUN pecl channel-update https://pecl.php.net/channel.xml \
+    && pecl install swoole
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 


### PR DESCRIPTION
Running `./vendor/bin/sail build` will throw an error when trying to install Swoole via PECL.

```
> [5/12] RUN pecl install swoole:
No releases available for package "pecl.php.net/swoole"
install failed
```

Reason for this is that the package index is missing and must first be updated.

This PR resolves the issue by extending the Dockerfile for PHP 8.0 to run `pecl channel-update` before trying to install Swoole.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
