### PR TITLE
Update Sail script to only exit if Main Exits

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -41,7 +41,7 @@ fi
 # Determine if Sail is currently up...
 PSRESULT="$(docker-compose ps -q)"
 
-if docker-compose ps | grep 'Exit'; then
+if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
     echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
     docker-compose down > /dev/null 2>&1


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

## Use case
Some containers are meant to exits early.
For example Every time on start up have a e2e container run tests on the new version.
And store the result for latter review.
However when you do ' sail logs ' to check what the output result of that container was.
sail notices you have a "exited container" and shutdowns everything.
This PR address this problem by only exiting the old process if the main services goes done.
