### PR TITLE
Add MySQL shell when running mariadb

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -227,6 +227,18 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Initiate a MySQL CLI terminal session within the "mysql" container...
+    elif [ "$1" == "mariadb" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                mariadb \
+                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+        else
+            sail_is_not_running
+        fi
+        
     # Initiate a PostgreSQL CLI terminal session within the "pgsql" container...
     elif [ "$1" == "psql" ]; then
         shift 1

--- a/bin/sail
+++ b/bin/sail
@@ -227,7 +227,7 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
-    # Initiate a MySQL CLI terminal session within the "mysql" container...
+    # Initiate a MySQL CLI terminal session within the "mariadb" container...
     elif [ "$1" == "mariadb" ]; then
         shift 1
 


### PR DESCRIPTION
Add option to Access the mysql shell when running mariadb in place of mysql service.

Running `sail mysql` is a very helpful tool to access mysql shell. 
With the addition of support for mariadb in #119 it would be really awesome to accord mariadb users to a similar experience.

This PR adds support to run: `sail mariadb` and access the good old MySQL shell.
![image](https://user-images.githubusercontent.com/1807304/116574063-08fb6580-a916-11eb-8dc6-d2524d8f2ce2.png)

Running `sail mysql` when running mariadb fails with the error `ERROR: No such service: mysql`

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
