### PR TITLE
fix mysql health check

### DIFF
--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -13,4 +13,4 @@
         networks:
             - sail
         healthcheck:
-          test: ["CMD", "mysqladmin", "ping"]
+          test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]


### PR DESCRIPTION
## What 
fix mysql.stub's healtcheck

## Why

when set `DB_PASSWORD` to env, many access denied error happen. like under below
![image](https://user-images.githubusercontent.com/18627334/117459580-84988a80-af86-11eb-82c1-8470f858f48d.png)

It is because mysqladmin for health check 's password wasn't set.

And you should re-check [this PR](https://github.com/laravel/sail/pull/96) 
