### PR TITLE
Add MinIO to sail:install Command

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -57,6 +57,7 @@ class InstallCommand extends Command
              'meilisearch',
              'mailhog',
              'selenium',
+             'minio',
          ], 0, null, true);
     }
 
@@ -83,7 +84,7 @@ class InstallCommand extends Command
 
         $volumes = collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
             })->map(function ($service) {
                 return "    sail{$service}:\n        driver: local";
             })->whenNotEmpty(function ($collection) {
@@ -131,6 +132,11 @@ class InstallCommand extends Command
         if (in_array('meilisearch', $services)) {
             $environment .= "\nSCOUT_DRIVER=meilisearch";
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
+        }
+
+        if (in_array('minio', $services)) {
+            $environment .= "\nMINIO_ROOT_USER=sail";
+            $environment .= "\nMINIO_ROOT_PASSWORD=password\n";
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -55,9 +55,9 @@ class InstallCommand extends Command
              'redis',
              'memcached',
              'meilisearch',
+             'minio',
              'mailhog',
              'selenium',
-             'minio',
          ], 0, null, true);
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -134,11 +134,6 @@ class InstallCommand extends Command
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
         }
 
-        if (in_array('minio', $services)) {
-            $environment .= "\nMINIO_ROOT_USER=sail";
-            $environment .= "\nMINIO_ROOT_PASSWORD=password\n";
-        }
-
         file_put_contents($this->laravel->basePath('.env'), $environment);
     }
 }

--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -1,0 +1,14 @@
+    minio:
+        image: 'minio/minio:latest'
+        ports:
+            - '${FORWARD_MINIO_PORT:-9000}:9000'
+        environment:
+            MINIO_ROOT_USER: '${MINIO_ROOT_USER}'
+            MINIO_ROOT_PASSWORD: '${MINIO_ROOT_PASSWORD}'
+        volumes:
+            - 'sailminio:/data/minio'
+        networks:
+            - sail
+        command: minio server /data/minio
+        healthcheck:
+          test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]

--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -3,8 +3,8 @@
         ports:
             - '${FORWARD_MINIO_PORT:-9000}:9000'
         environment:
-            MINIO_ROOT_USER: '${MINIO_ROOT_USER}'
-            MINIO_ROOT_PASSWORD: '${MINIO_ROOT_PASSWORD}'
+            MINIO_ROOT_USER: 'sail'
+            MINIO_ROOT_PASSWORD: 'password'
         volumes:
             - 'sailminio:/data/minio'
         networks:


### PR DESCRIPTION
This PR add support for [MinIO](https://min.io/) ([GitHub](https://github.com/minio/minio/blob/master/docs/docker/README.md)) to Sail during the install process. It includes a `minio.stub` file to be included in the final `docker-compse.yml` file and updates to the `InstallCommand`.

MinIO is an S3 compatible object storage service and is a great compliment to the Laravel development experience so you don't have to use dev S3 buckets.
