### PR TITLE
Clear pecl caches & tmp files during swoole extension install

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -42,7 +42,9 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 RUN pecl channel-update https://pecl.php.net/channel.xml \
-    && pecl install swoole
+    && pecl install swoole \
+    && pecl clear-cache \
+    && rm -rf /tmp/* /var/tmp/*
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 


### PR DESCRIPTION
`pecl install swoole` writes a number of files into /tmp when compiling the extension. 

This PR runs some cleanup commands to reduce the data stored in that docker image layer 