### PR TITLE
fix hard coded uid

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
+ARG WWWUSER
 
 WORKDIR /var/www/html
 
@@ -44,7 +45,7 @@ RUN apt-get update \
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php7.4
 
 RUN groupadd --force -g $WWWGROUP sail
-RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u $WWWUSER sail
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -3,6 +3,7 @@ FROM ubuntu:20.04
 LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
+ARG WWWUSER
 
 WORKDIR /var/www/html
 
@@ -49,7 +50,7 @@ RUN pecl channel-update https://pecl.php.net/channel.xml \
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 
 RUN groupadd --force -g $WWWGROUP sail
-RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u $WWWUSER sail
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -7,6 +7,7 @@ services:
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
+                WWWUSER: '${WWWUSER}'
         image: sail-8.0/app
         ports:
             - '${APP_PORT:-80}:80'


### PR DESCRIPTION
I found user `sail` UID is hardcoded as `1337`  in Dockerfile and couldn't find the benefits. This pull request use `WWWUSER` to define UID like as `WWWGROUP` define GID. The current config doesn't seem to cause problems so far, but mounting volume may fail if files are generated by the user in the docker building process. Thank you!