### PR TITLE
[1.x] Optional Xdebug 3.0 support

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -41,6 +41,23 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+ARG XDEBUG
+ARG XDEBUG_START
+ARG XDEBUG_PORT
+ARG XDEBUG_CLIENT
+RUN if [ "${XDEBUG}" = 'true' ]; then \
+    pecl channel-update https://pecl.php.net/channel.xml \
+    && pecl install xdebug \
+    && pecl clear-cache \
+    && echo "[XDebug]" > /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "zend_extension = \"$(find /usr/lib/php/ -name xdebug.so | sort -z | head -n 1)\"" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_port = ${XDEBUG_PORT}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.mode = debug" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.start_with_request = ${XDEBUG_START}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_host = ${XDEBUG_CLIENT}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && rm -rf /tmp/* /var/tmp/* ; \
+fi;
+
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php7.4
 
 RUN groupadd --force -g $WWWGROUP sail

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -46,6 +46,23 @@ RUN pecl channel-update https://pecl.php.net/channel.xml \
     && pecl clear-cache \
     && rm -rf /tmp/* /var/tmp/*
 
+ARG XDEBUG
+ARG XDEBUG_START
+ARG XDEBUG_PORT
+ARG XDEBUG_CLIENT
+RUN if [ "${XDEBUG}" = 'true' ]; then \
+    pecl channel-update https://pecl.php.net/channel.xml \
+    && pecl install xdebug \
+    && pecl clear-cache \
+    && echo "[XDebug]" > /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "zend_extension = \"$(find /usr/lib/php/ -name xdebug.so | sort -z | head -n 1)\"" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_port = ${XDEBUG_PORT}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.mode = debug" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.start_with_request = ${XDEBUG_START}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && echo "xdebug.client_host = ${XDEBUG_CLIENT}" >> /etc/php/8.0/cli/conf.d/php-ext-xdebug.ini \
+    && rm -rf /tmp/* /var/tmp/* ; \
+fi;
+
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 
 RUN groupadd --force -g $WWWGROUP sail

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -7,6 +7,10 @@ services:
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
+                XDEBUG: '${SAIL_XDEBUG:-false}'
+                XDEBUG_PORT: '${SAIL_XDEBUG_PORT:-9000}'
+                XDEBUG_CLIENT: '${SAIL_XDEBUG_CLIENT:-host.docker.internal}'
+                XDEBUG_START: '${SAIL_XDEBUG_START:-yes}'
         image: sail-8.0/app
         ports:
             - '${APP_PORT:-80}:80'

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -10,7 +10,7 @@ services:
                 XDEBUG: '${SAIL_XDEBUG:-false}'
                 XDEBUG_PORT: '${SAIL_XDEBUG_PORT:-9000}'
                 XDEBUG_CLIENT: '${SAIL_XDEBUG_CLIENT:-host.docker.internal}'
-                XDEBUG_START: '${SAIL_XDEBUG_START:-yes}'
+                XDEBUG_START: '${SAIL_XDEBUG_START:-trigger}'
         image: sail-8.0/app
         ports:
             - '${APP_PORT:-80}:80'


### PR DESCRIPTION
Updated 7.4 and 8.0 Dockerfiles to (optionally) install and activate Xdebug in laravel.test service.

Support is disabled by default, and the port/host to contact, and the xdebug start mode is configurable.

Credit to @acabutto for the original work in PR #48 and @isometriq for feedback.

Note; installing xdebug should be done after any extensions using pecl or with the xdebug start mode set to `trigger`/`off`. As otherwise debugger callbacks can occur during a docker image build.