### PR TITLE
[1.x] Ask for OS in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1_Bug_report.md
@@ -6,7 +6,7 @@ about: 'Report a general library issue. Please ensure your version is still supp
 - Sail Version: #.#.#
 - Laravel Version: #.#.#
 - PHP Version: #.#.#
-- Database Driver & Version:
+- OS: Windows / Linux / macOS #.#.#
 
 ### Description:
 


### PR DESCRIPTION
This will help us determine which OS they're attempting to run Sail on. I've also removed the Database Driver since that isn't really relevant for Sail bug reports.