### PR TITLE
Add retries & timeout to healthcheck

### DIFF
--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -14,3 +14,5 @@
             - sail
         healthcheck:
           test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+          retries: 3
+          timeout: 5s

--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -12,3 +12,5 @@
         command: minio server /data/minio
         healthcheck:
           test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+          retries: 3
+          timeout: 5s

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -14,3 +14,5 @@
             - sail
         healthcheck:
           test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+          retries: 3
+          timeout: 5s

--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -13,3 +13,5 @@
             - sail
         healthcheck:
           test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
+          retries: 3
+          timeout: 5s

--- a/stubs/redis.stub
+++ b/stubs/redis.stub
@@ -8,3 +8,5 @@
             - sail
         healthcheck:
           test: ["CMD", "redis-cli", "ping"]
+          retries: 3
+          timeout: 5s


### PR DESCRIPTION
This small patch will help with the support of podman, as some options are required unlike with docker-compose.
should not have any side effects, and even can help if for some reason the service is not ready.

```
ERROR: for redis  Cannot create container for service redis: fill out specgen: healthcheck-retries must be greater than 0
ERROR: Encountered errors while bringing up the project.
```
