### PR TITLE
[1.x] Append is running check

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -301,6 +301,15 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Check is running...
+    elif [ "$1" == "is-running" ]; then
+
+        if [ "$EXEC" == "yes" ]; then
+            exit 0;
+        else
+            sail_is_not_running
+        fi
+
     # Pass unknown commands to the "docker-compose" binary...
     else
         docker-compose "$@"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Command `is-running` returns exit code `0` if sail is running else call `sail_is_not_running` with exit code `1`.

Use case:
```shell
sail is-running 2> /dev/null \
    && echo "action if sail is running" \
    || echo "action if sail is not running" 
```