### PR TITLE
[1.x] Append MeiliSearch HealthCheck

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -6,3 +6,7 @@
             - 'sailmeilisearch:/data.ms'
         networks:
             - sail
+        healthcheck:
+          test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
+          retries: 3
+          timeout: 5s


### PR DESCRIPTION
Adding these healthchecks allows a user to check the availability and status of a container and allows docker-compose services to wait on services they depend on to be healthy before starting themselves.