### PR TITLE
[1.x] Append MeiliSearch and MinIO to depends

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -71,7 +71,7 @@ class InstallCommand extends Command
     {
         $depends = collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'selenium']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio', 'selenium']);
             })->map(function ($service) {
                 return "            - {$service}";
             })->whenNotEmpty(function ($collection) {


### PR DESCRIPTION
If you are using MeiliSearch for Scout or MinIO for Storage, you must be make sure they are running, even if they are optional, just like Redis.