### PR TITLE
[1.x] Disable tty allocation in docker-compose commands

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -86,7 +86,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 "$APP_SERVICE" \
                 composer "$@"
@@ -112,7 +112,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan test "$@"
@@ -125,7 +125,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 -e "APP_URL=http://laravel.test" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -140,7 +140,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 -e "APP_URL=http://laravel.test" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -181,7 +181,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 "$APP_SERVICE" \
                 npm "$@"
@@ -194,7 +194,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 "$APP_SERVICE" \
                 npx "$@"
@@ -207,7 +207,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose exec -T \
                 -u sail \
                 "$APP_SERVICE" \
                 yarn "$@"


### PR DESCRIPTION
Today, the docker-compose commands used by the sail script have this format (with exceptions):

```shell
docker-compose exec \
    -u sail \
    service_name
    command "$@"
```
Although it works very well, when the commands are executed by another script or software (such as an IDE), you get the following error message:

```shell
the input device is not a TTY
```
This is because by default, Docker tries to allocate an interactive shell for the user. However, in some situations, such as when executing a "sail test", this allocation isn't necessary, since there is no user interaction, only viewing the response to a specific request. 

That said, the addition of the "-T" flag to docker-compose commands that have this non-interactive nature, not only doesn't impact the actual functioning, it also allows such commands to be used by other scripts (hooks git, for example), which would improve the development flow.

