### PR TITLE
[1.x] Add proxy to vendor binaries

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -81,6 +81,19 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy the vendor binaries commands on the application container...
+    if [ "$1" == "bin" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec -T \
+                -u sail \
+                "$APP_SERVICE" \
+                ./vendor/bin/"$@"
+        else
+            sail_is_not_running
+        fi
+
     # Proxy Composer commands to the "composer" binary on the application container...
     elif [ "$1" == "composer" ]; then
         shift 1

--- a/bin/sail
+++ b/bin/sail
@@ -81,7 +81,7 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
-    # Proxy the vendor binaries commands on the application container...
+    # Proxy vendor binary commands on the application container...
     if [ "$1" == "bin" ]; then
         shift 1
 

--- a/bin/sail
+++ b/bin/sail
@@ -86,7 +86,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec -T \
+            docker-compose exec \
                 -u sail \
                 "$APP_SERVICE" \
                 ./vendor/bin/"$@"


### PR DESCRIPTION
Including a proxy for the binaries in the vendor folder, in addition to decreasing the steps for its execution (which today needs to be done via `sail shell` and then `vendor/bin/binary`), also allows other scripts to run these binaries from simplest way. An example would be the use of *php-cs-fixer*, *phpmd* or other static parser, not only via terminal (executed by the user) but also via a hook for commits or push.

Running a vendor binary today:
```shell
sail shell
vendor/bin/php-cs-fixer ...
```

Running a vendor binary with the proxy:
```shell
sail bin php-cs-fixer ...
```

According to [Docker docs](https://docs.docker.com/compose/reference/), the "bin" word is not used for any specific command in the docker-compose cli, so this addition will not break the existing structure
