### PR TITLE
[1.x] Update Sail script to only exit if Main Exits

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -41,7 +41,7 @@ fi
 # Determine if Sail is currently up...
 PSRESULT="$(docker-compose ps -q)"
 
-if docker-compose ps | grep 'Exit'; then
+if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
     echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
     docker-compose down > /dev/null 2>&1


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This is a small change that should help people who like to run e2e tests in containers defined in there docker-compose or any other short lived container.
This patch changes the behavior of Laravel sail to only shutdown the containers if and only if the main PHP containers goes down.
before this patch if any service defined `docker-compose.yaml`  would shutdown for any reason. so would all other containers upon excuting any `sail` command

Which meant that if you would try to Debug or restart that one service.
for example if you would like to inspect the logs of that container with for example  `sail logs <servicename>` 
it would shutdown all containers because it found a stopped container.
This patch should change this behavior to only stop the stack if the main service goes down
