### PR TITLE
add default values for user and user group in docker-compose.stub

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -93,6 +93,8 @@ class InstallCommand extends Command
 
         $dockerCompose = file_get_contents(__DIR__ . '/../../stubs/docker-compose.stub');
 
+        $dockerCompose = str_replace('{{useruid}}', getmyuid(), $dockerCompose);
+        $dockerCompose = str_replace('{{usergid}}', getmygid(), $dockerCompose);
         $dockerCompose = str_replace('{{depends}}', empty($depends) ? '' : '        '.$depends, $dockerCompose);
         $dockerCompose = str_replace('{{services}}', $stubs, $dockerCompose);
         $dockerCompose = str_replace('{{volumes}}', $volumes, $dockerCompose);

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -6,12 +6,12 @@ services:
             context: ./vendor/laravel/sail/runtimes/8.0
             dockerfile: Dockerfile
             args:
-                WWWGROUP: '${WWWGROUP}'
+                WWWGROUP: '${WWWGROUP:-{{usergid}}}'
         image: sail-8.0/app
         ports:
             - '${APP_PORT:-80}:80'
         environment:
-            WWWUSER: '${WWWUSER}'
+            WWWUSER: '${WWWUSER:-{{useruid}}}'
             LARAVEL_SAIL: 1
         volumes:
             - '.:/var/www/html'


### PR DESCRIPTION
User and group setting is confusing when using a docker-compose.yml without using `./vendor/bin/sail up`

Installing the example generates a docker-compose file that does not contain default values for user and group.

When running application via `./vendor/bin/sail up`, the problem is not observed, because the export takes in ./vendor/bin/sail:25
```
export WWWUSER=${WWWUSER:-$UID}
export WWWGROUP=${WWWGROUP:-$(id -g)}
```
When run with `docker-compose up -d` command, I have build error, because there are no such variables in `.env`. I suggest  change the default values automatically in install process

