### PR TITLE
Share/Expose options and cleanup on exit

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -24,6 +24,9 @@ export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
+export SHARE_DASHBOARD=${SHARE_DASHBOARD:-4040}
+export SHARE_SERVER_HOST=${SHARE_SERVER_HOST:-"laravel-sail.site"}
+export SHARE_SERVER_PORT=${SHARE_SERVER_PORT:-8080}
 
 if [ "$MACHINE" == "linux" ]; then
     export SEDCMD="sed -i"
@@ -306,9 +309,10 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker run --init beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
-            --server-host=laravel-sail.site \
-            --server-port=8080 \
+            docker run --init --rm -p $SHARE_DASHBOARD:4040 beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            --server-host="$SHARE_SERVER_HOST" \
+            --server-port="$SHARE_SERVER_PORT" \
+            --auth="$SHARE_TOKEN" \
             "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
I have started to use the share command and I prefer to use a different server to default.
This PR allows people to set some of the main options in `.env` so they don't have to add them on the end of the `sail share` command every time.

I also noticed that the expose container does not get removed when you stop sharing - every time you run the command a new container will be created, to fix this issue I added `-rm` which will remove the container upon exiting

#### Example:
##### Before
```
sail share --server-host=custom-server.com --domain=domain1.com --subdomain=subdomain --auth=amazing-auth-token
```

##### After

```
SHARE_DASHBOARD=4000
SHARE_SERVER_HOST=custom-server.com
SHARE_TOKEN=amazing-auth-token
```

```
sail share --domain=domain1.com --subdomain=subdomain
```
