### PR TITLE
[1.x] Update to Ubuntu 21.04

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 LABEL maintainer="Taylor Otwell"
 

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:21.04
 
 LABEL maintainer="Taylor Otwell"
 


### PR DESCRIPTION
This updates the default Ubuntu version to 21.04 which hopefully will solve the current libssl issues people are experiencing.