### PR TITLE
[1.x] Append random subdomain by default.

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -28,6 +28,7 @@ export WWWGROUP=${WWWGROUP:-$(id -g)}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-"$(cat /dev/random | LC_CTYPE=C tr -dc "[:alpha:]" | head -c 12)"}
 
 if [ "$MACHINE" == "linux" ]; then
     export SEDCMD="sed -i"
@@ -314,6 +315,7 @@ if [ $# -gt 0 ]; then
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
+            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
             "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
## Problem
If run `sail share` without `--subdomain` param, [this code](https://github.com/beyondcode/expose/blob/97993318e737a422075444cfe8d180415ed43180/app/Commands/ShareCommand.php#L41-L44) setup `http` as subdomain.
## Solution
Append optional env variable. Order of applying parameters:
1. Highest priority `sail share --subdomain=subdomain`
2. Second priority `.env` variable `SAIL_SHARE_SUBDOMAIN`
3. Third priority random subdomain from sail binary

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
