### PR TITLE
[1.x] Append random subdomain by default.

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -310,10 +310,11 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
+            --subdomain=""
             "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
Please check comments from laravel/sail#170. 

I'm research **expose** code and found what without empty `--subdomain` option **expose** use `http` from `http://host.docker.internal:80` (`{host}` argument) as subdomain.

This change set empty subdomain as default, but if you use this option in `sail share` command it rewrite default value.

```shell
sail share                      # expose generate random subdomain
sail share --subdomain=test     # use test as subdomain
```

<hr>

**P.S.** The `-t` flag for `docker run` allows you to output the remaining time on one line, rather than every second on a separate line.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
