### PR TITLE
add default password to redis service

### DIFF
--- a/stubs/redis.stub
+++ b/stubs/redis.stub
@@ -1,5 +1,6 @@
     redis:
         image: 'redis:alpine'
+        command: redis-server --requirepass "${REDIS_PASSWORD}"
         ports:
             - '${FORWARD_REDIS_PORT:-6379}:6379'
         volumes:


### PR DESCRIPTION
The current stub for Redis config does not consider default password. If user sets a REDIS_PASSWORD in env file, it leads to an error, `RedisException ERR AUTH <password> called without any password configured for the default user.`
This PR fixes this problem.