### PR TITLE
[1.x] Add pcov to php 8.0 runtime

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update \
        php8.0-curl php8.0-memcached \
        php8.0-imap php8.0-mysql php8.0-mbstring \
        php8.0-xml php8.0-zip php8.0-bcmath php8.0-soap \
-       php8.0-intl php8.0-readline \
+       php8.0-intl php8.0-readline php8.0-pcov \
        php8.0-msgpack php8.0-igbinary php8.0-ldap \
        php8.0-redis php8.0-swoole \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \


### PR DESCRIPTION
This adds PCOV code coverage tool to 8.0 runtime.

I know this is customizable, but since 7.4 runtime has it enabled, it would be nice to have it enabled on the 8.0 as well.