### PR TITLE
[1.x] Fix logo for Packagist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><img src="/art/logo.svg" alt="Logo Laravel Sail"></p>
+<p align="center"><img src="https://raw.githubusercontent.com/laravel/sail/HEAD/art/logo.svg" alt="Logo Laravel Sail"></p>
 
 <p align="center">
     <a href="https://packagist.org/packages/laravel/sail">


### PR DESCRIPTION
The logo isn't displayed in `Packagist` because of the relative file path. This fix makes the full path to `HEAD`.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
