### PR TITLE
Minio Console Port

### DIFF
--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -2,6 +2,7 @@
         image: 'minio/minio:latest'
         ports:
             - '${FORWARD_MINIO_PORT:-9000}:9000'
+            - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
         environment:
             MINIO_ROOT_USER: 'sail'
             MINIO_ROOT_PASSWORD: 'password'
@@ -9,7 +10,7 @@
             - 'sailminio:/data/minio'
         networks:
             - sail
-        command: minio server /data/minio
+        command: minio server /data/minio --console-address ":8900"
         healthcheck:
           test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
           retries: 3


### PR DESCRIPTION
Added Added Minio console port. Default set to 8900 but subject to approval by the community. 
---
Fixes an issue where Minio show the following error in the logs and on opening localhost:9000 redirects to a random port.

```
WARNING: Console endpoint is listening on a dynamic port (41045), please use --console-address ":PORT" to choose a static port.
```
This PR allows one to access Minio dashboard on port 8900 and the API endpoint remains on port 9000. 

Example repo: https://github.com/SamuelMwangiW/sail-minio-example/

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
