### PR TITLE
Fixes missing backslash

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -308,7 +308,7 @@ if [ $# -gt 0 ]; then
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
-            --subdomain=""
+            --subdomain="" \
             "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
This line is missing a backslash, causing commands not to be passed. So using `--subdomain` has no effect, and it always use the randomized one.