### PR TITLE
make sail script publishable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+if [ $(dirname $0) != . ] && [ -f ./sail ]; then
+    if [ ! -x ./sail ]; then
+        chmod +x ./sail
+    fi
+    bash ./sail "$@"
+    exit 0
+fi
+
 UNAMEOUT="$(uname -s)"
 
 WHITE='\033[1;37m'

--- a/bin/sail
+++ b/bin/sail
@@ -1,13 +1,5 @@
 #!/usr/bin/env bash
 
-if [ $(dirname $0) != . ] && [ -f ./sail ]; then
-    if [ ! -x ./sail ]; then
-        chmod +x ./sail
-    fi
-    bash ./sail "$@"
-    exit 0
-fi
-
 UNAMEOUT="$(uname -s)"
 
 WHITE='\033[1;37m'

--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -46,8 +46,7 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
             $this->publishes([
                 __DIR__ . '/../runtimes' => $this->app->basePath('docker'),
             ], ['sail', 'sail-docker']);
-            
-            
+
             $this->publishes([
                 __DIR__ . '/../bin/sail' => $this->app->basePath('sail'),
             ], ['sail', 'sail-bin']);

--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -45,6 +45,7 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__ . '/../runtimes' => $this->app->basePath('docker'),
+                __DIR__ . '/../bin/sail' => $this->app->basePath('sail'),
             ], 'sail');
         }
     }


### PR DESCRIPTION
This PR will allow developers to modify or add commands to the sail script.
If you decided to add a new custom service to the docker-compose.yml file and expose a command for this service via sail, you may add the command to the published sail script at the root of your app. For example, if you added a mongo service to your app you can make the mongo shell available by adding:

```bash
.
.
elif [ "$1" == "mongo" ]; then

    if [ "$EXEC" == "yes" ]; then
        docker-compose exec mongo mongo
    else
        sail_is_not_running
    fi
elif
.
.
```

Currently, the script will be published by executing `sail artisan sail:publish` command, I was wondering if it should be published via its own command like `sail artisan sail:publish-script` so that developers can publish it on demand.

Also, The user doesn't have to register any alias command, the script will check if there is a file called `sail` at the root of the app, then it will execute it, otherwise, it will execute the original script in `./vendor/bin/sail`.