### PR TITLE
[1.x] Publish only docker directory

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -27,7 +27,7 @@ class PublishCommand extends Command
      */
     public function handle()
     {
-        $this->call('vendor:publish', ['--tag' => 'sail']);
+        $this->call('vendor:publish', ['--tag' => 'sail-docker']);
 
         file_put_contents(
             $this->laravel->basePath('docker-compose.yml'), 


### PR DESCRIPTION
In #201 to tag `sail` added bash script and added separate tag `sail-docker` to publish only docker directory

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
