### PR TITLE
adds devcontainer to install command

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -11,7 +11,9 @@ class InstallCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'sail:install {--with= : The services that should be included in the installation}';
+    protected $signature = 'sail:install
+                {--with= : The services that should be included in the installation}
+                {--devcontainer : Create a .devcontainer configuration directory}';
 
     /**
      * The console command description.
@@ -37,7 +39,10 @@ class InstallCommand extends Command
 
         $this->buildDockerCompose($services);
         $this->replaceEnvVariables($services);
-        $this->installDevContainer();
+
+        if ($this->option('devcontainer')) {
+            $this->installDevContainer();
+        }
 
         $this->info('Sail scaffolding installed successfully.');
     }
@@ -139,17 +144,19 @@ class InstallCommand extends Command
     }
 
     /**
-     * Install the Dev Container file.
+     * Install the devcontainer.json configuration file.
      *
      * @return void
      */
     protected function installDevContainer()
     {
-        $devContainer = file_get_contents(__DIR__ . '/../../stubs/devcontainer.stub');
-        // create .devcontainer folder if it doesn't exist
-        if (!file_exists($this->laravel->basePath('.devcontainer'))) {
-            mkdir($this->laravel->basePath('.devcontainer'), 0777, true);
+        if (! is_dir($this->laravel->basePath('.devcontainer'))) {
+            mkdir($this->laravel->basePath('.devcontainer'), 0755, true);
         }
-        file_put_contents($this->laravel->basePath('.devcontainer/devcontainer.json'), $devContainer);
+
+        file_put_contents(
+            $this->laravel->basePath('.devcontainer/devcontainer.json'),
+            file_get_contents(__DIR__.'/../../stubs/devcontainer.stub')
+        );
     }
 }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -37,6 +37,7 @@ class InstallCommand extends Command
 
         $this->buildDockerCompose($services);
         $this->replaceEnvVariables($services);
+        $this->installDevContainer();
 
         $this->info('Sail scaffolding installed successfully.');
     }
@@ -135,5 +136,20 @@ class InstallCommand extends Command
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);
+    }
+
+    /**
+     * Install the Dev Container file.
+     *
+     * @return void
+     */
+    protected function installDevContainer()
+    {
+        $devContainer = file_get_contents(__DIR__ . '/../../stubs/devcontainer.stub');
+        // create .devcontainer folder if it doesn't exist
+        if (!file_exists($this->laravel->basePath('.devcontainer'))) {
+            mkdir($this->laravel->basePath('.devcontainer'), 0777, true);
+        }
+        file_put_contents($this->laravel->basePath('.devcontainer/devcontainer.json'), $devContainer);
     }
 }

--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -1,45 +1,22 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/docker-existing-docker-compose
+// https://aka.ms/devcontainer.json
 {
 	"name": "Existing Docker Compose (Extend)",
-
-	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
 	"dockerComposeFile": [
 		"../docker-compose.yml"
 	],
-
-	// The 'service' property is the name of the service for the container that VS Code should use.
 	"service": "laravel.test",
-
-	// The optional 'workspaceFolder' property is the path VS Code should open by default when
-	// connected. This is typically a file mount in ../docker-compose.yml
 	"workspaceFolder": "/var/www/html",
-
-	// Set *default* container specific settings.json values on container create.
 	"settings": {},
-
-	// Add the IDs of extensions you want installed when the container is created.
-    // here we could add PHP related extensions that are relevant to laravel.
 	"extensions": [
-		"mikestead.dotenv",
-		"amiralizadeh9480.laravel-extra-intellisense",
-		"ryannaddy.laravel-artisan",
-		"onecentlin.laravel5-snippets",
-		"onecentlin.laravel-blade"
+		// "mikestead.dotenv",
+		// "amiralizadeh9480.laravel-extra-intellisense",
+		// "ryannaddy.laravel-artisan",
+		// "onecentlin.laravel5-snippets",
+		// "onecentlin.laravel-blade"
 	],
-
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"remoteUser": "sail",
 	// "forwardPorts": [],
-
-	// Uncomment the next line if you want start specific services in your Docker Compose config.
 	// "runServices": [],
-
-	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
-	"shutdownAction": "none",
-
-	// Uncomment the next line to run commands after the container is created - for example installing curl.
 	// "postCreateCommand": "apt-get update && apt-get install -y curl",
-
-	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "sail"
+	// "shutdownAction": "none",
 }

--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -1,0 +1,45 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.183.0/containers/docker-existing-docker-compose
+{
+	"name": "Existing Docker Compose (Extend)",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	"dockerComposeFile": [
+		"../docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should use.
+	"service": "laravel.test",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in ../docker-compose.yml
+	"workspaceFolder": "/var/www/html",
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+
+	// Add the IDs of extensions you want installed when the container is created.
+    // here we could add PHP related extensions that are relevant to laravel.
+	"extensions": [
+		"mikestead.dotenv",
+		"amiralizadeh9480.laravel-extra-intellisense",
+		"ryannaddy.laravel-artisan",
+		"onecentlin.laravel5-snippets",
+		"onecentlin.laravel-blade"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	"shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created - for example installing curl.
+	// "postCreateCommand": "apt-get update && apt-get install -y curl",
+
+	// Uncomment to connect as a non-root user if you've added one. See https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "sail"
+}


### PR DESCRIPTION
I'm working with the VS Code & GitHub teams and we like to propose the following idea.

When working in projects that have a complex infrastructure - say a MySQL backend, with Redis for caching - it's hard to get the project started due to infrastructure setup. Thanks to Sail, Laravel addresses most of those problems, making it easy to start new projects. We want to improve that experience even further by enabling the current project setup to “just work” in VS Code.

Imagine opening a folder with a Laravel project and the editor takes care of setting up the environment automatically for the user. Not only on the infrastructure level, but also installing the required editor extensions so the developer can start hacking right away.

By adding a `.devcontainer/devcontainer.json` file to a project VS Code will detect that the project can be opened inside a container and do all the heavy lifting for the user. 

A more detailed description of this feature can be found here: https://github.com/laravel/ideas/issues/2660

Here's the `.devcontainer.json` documentation https://code.visualstudio.com/docs/remote/devcontainerjson-reference

Since Sail already does most of the heavy lifting for a user when it comes to containers, adding a `.devcontainer.json` to a project is the natural next step. This would allow VS Code to fire up the containers after prompting the user for confirmation. Once the user has told VS Code to start the containers, VS Code will use the `docker-compose` generated by Sail to start those containers, and connect remotely to them, so the user has a development environment that's ready to work in the containers.

Besides the container side of the PR, it also suggests a list of Laravel extensions for VS Code, in order to provide a sort of standardized dev environment for Laravel developers. Of course the list suggested [here](https://github.com/laravel/sail/compare/master...videlalvaro:devcontainers?expand=1#diff-2e36ce2a0870fd3428861f11058e72e0ab610c79fc78b83325c49510b0356177R23) can be improved. 

## Caveat ##

For this to work auto-magically with VS Code the `.env` file requires the following variables to be set:

Also based on the installed services we could specify a list of ports to be forwarded to the user computer.

```
WWWGROUP=1000
WWWUSER=1000
```

If the team thinks it's OK to add that to the `.env` file then I could update the PR accordingly.
