### PR TITLE
Pass additional arguments to shell / root-shell commands

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -271,7 +271,7 @@ if [ $# -gt 0 ]; then
             docker-compose exec \
                 -u sail \
                 "$APP_SERVICE" \
-                bash
+                bash "$@"
         else
             sail_is_not_running
         fi
@@ -283,7 +283,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 "$APP_SERVICE" \
-                bash
+                bash "$@"
         else
             sail_is_not_running
         fi


### PR DESCRIPTION
Add `"$@"` to pass additional command-line arguments for `shell` / `root-shell` to `bash` in container.

This allows things like `sail shell -c "cd some-sub-module && npm install"`

