### PR TITLE
Added xdebug 3.0 to the project using xdebugs built-in env vars.

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -119,6 +119,20 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy the "debug" command to the "php artisan" binary on the application container with xdebug enabled...
+    elif [ "$1" == "debug" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            docker-compose exec \
+                -u sail \
+                -e XDEBUG_SESSION=1 \
+                "$APP_SERVICE" \
+                php artisan "$@"
+        else
+            sail_is_not_running
+        fi
+
     # Proxy the "test" command to the "php artisan test" Artisan command...
     elif [ "$1" == "test" ]; then
         shift 1

--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
        php7.4-xml php7.4-zip php7.4-bcmath php7.4-soap \
        php7.4-intl php7.4-readline php7.4-pcov \
        php7.4-msgpack php7.4-igbinary php7.4-ldap \
-       php7.4-redis \
+       php7.4-redis php7.4-xdebug \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
        php8.0-xml php8.0-zip php8.0-bcmath php8.0-soap \
        php8.0-intl php8.0-readline php8.0-pcov \
        php8.0-msgpack php8.0-igbinary php8.0-ldap \
-       php8.0-redis php8.0-swoole \
+       php8.0-redis php8.0-swoole php8.0-xdebug \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -13,6 +13,8 @@ services:
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
         volumes:
             - '.:/var/www/html'
         networks:


### PR DESCRIPTION
I'm aware that this has been attempted in previous PRs that have been denied but I thought I'd take another chance as I believe my implementation has a rather small footprint and may be more palatable to the maintainers of this repository. 

I do understand their desire to keep this project lean but I have a hard time understanding how a step debugger isn't included in any basic local development environment.

### Implementation

This installs Xdebug 3.0 using the php7.4 and php8.0 packages and relies on the two built in env vars already provided by xdebug: `XDEBUG_MODE` and `XDEBUG_CONFIG` to control and configure the extension. These are mapped directly to `SAIL_XDEBUG_MODE` and `SAIL_XDEBUG_CONFIG` that can be controlled in the projects .env file.

### Configuraiton

[XDEBUG_MODE](https://xdebug.org/docs/step_debug#mode) is set to `off` by default. To enable xdebug you simply need to set the appropriate mode when starting your containers:

```bash
SAIL_XDEBUG_MODE=develop,debug
```

[XDEBUG_CONFIG](https://xdebug.org/docs/all_settings#mode) is set to `client_host=host.docker.internal` by default so it will be properly configured out of the box to work on Mac and Windows. 

Since **host.docker.internal** isn't available in containers running on Linux hosts, Linux users need to update this env var in their projects:

```bash
SAIL_XDEBUG_CONFIG="client_host=<host-ip-address>"
```

They can get the host ip address by running the following command:

```bash
docker inspect -f {{range.NetworkSettings.Networks}}{{.Gateway}}{{end}} <container-name>
```

### CLI Usage

I added a `sail debug` command that can be used to start a debugging session when running an artisan command:

    # Without xdebug:
    sail artisan foo:bar

    # With xdebug:
    sail debug foo:bar

    # Without xdebug:
    sail test

    # With xdebug:
    sail debug test

### Browser Usage

If you want to debug a web session, follow the instructions provided by xdebug for initiating an xdebug session from the web browser.

[Browser Extensions](https://xdebug.org/docs/step_debug#browser-extensions)

### Current Issue

There is currently an issue with the `serve` command that prevents xdebug configured via env variables from working with the built-in webserver but I've included a PR to laravel/framework to alleviate this: https://github.com/laravel/framework/pull/38211

Once that is merged in we can fix this issue by overriding the env vars that are passed thru to the built-in webserver:

    $this->app->singleton('command.serve', function() {
            return new ServeCommand([
                    'APP_ENV',
                    'LARAVEL_SAIL',
                    'PHP_CLI_SERVER_WORKERS',
                    'XDEBUG_MODE',
                    'XDEBUG_CONFIG',
            ]);
    });