### PR TITLE
Custom sail script to publish

### DIFF
--- a/bin/publish-sail
+++ b/bin/publish-sail
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+export SAIL_CUSTOM=true
+
+UNAMEOUT="$(uname -s)"
+
+WHITE='\033[1;37m'
+NC='\033[0m'
+
+# Verify operating system is supported...
+case "${UNAMEOUT}" in
+    Linux*)             MACHINE=linux;;
+    Darwin*)            MACHINE=mac;;
+    *)                  MACHINE="UNKNOWN"
+esac
+
+if [ "$MACHINE" == "UNKNOWN" ]; then
+    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
+
+    exit 1
+fi
+
+# Source the ".env" file so Laravel's environment variables are available...
+if [ -f ./.env ]; then
+    source ./.env
+fi
+
+# Define environment variables...
+export APP_PORT=${APP_PORT:-80}
+export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export DB_PORT=${DB_PORT:-3306}
+export WWWUSER=${WWWUSER:-$UID}
+export WWWGROUP=${WWWGROUP:-$(id -g)}
+
+export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
+export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
+export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+
+# Ensure that Docker is running...
+if ! docker info > /dev/null 2>&1; then
+    echo -e "${WHITE}Docker is not running.${NC}" >&2
+
+    exit 1
+fi
+
+# Determine if Sail is currently up...
+PSRESULT="$(docker-compose ps -q)"
+
+if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+    echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
+
+    docker-compose down > /dev/null 2>&1
+
+    EXEC="no"
+elif [ -n "$PSRESULT" ]; then
+    EXEC="yes"
+else
+    EXEC="no"
+fi
+
+# Function that outputs Sail is not running...
+function sail_is_not_running {
+    echo -e "${WHITE}Sail is not running.${NC}" >&2
+    echo "" >&2
+    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+
+    exit 1
+}
+
+if [ $# -gt 0 ]; then
+    # Initiate the project configuration by running composer install...
+    if [ "$1" == "config" ]; then
+
+        docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -v $(pwd):/opt \
+            -w /opt \
+            laravelsail/php80-composer:latest \
+            composer install --ignore-platform-reqs
+
+        if [ ! -f './.env' ]; then
+            cp .env.example .env
+        fi
+
+    # First option of custom commands.
+    elif [ "$1" == "first-custom" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            echo "your command here"
+        else
+            sail_is_not_running
+        fi
+
+    # Second option of custom commands.
+    elif [ "$1" == "second-custom" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            echo "your other command here"
+        else
+            sail_is_not_running
+        fi
+
+    else
+        ./vendor/bin/sail "$@"
+    fi
+
+else
+    docker-compose ps
+fi

--- a/bin/sail
+++ b/bin/sail
@@ -1,69 +1,71 @@
 #!/usr/bin/env bash
 
-UNAMEOUT="$(uname -s)"
+if [ -z "${SAIL_CUSTOM}" ]; then
+    UNAMEOUT="$(uname -s)"
 
-WHITE='\033[1;37m'
-NC='\033[0m'
+    WHITE='\033[1;37m'
+    NC='\033[0m'
 
-# Verify operating system is supported...
-case "${UNAMEOUT}" in
-    Linux*)             MACHINE=linux;;
-    Darwin*)            MACHINE=mac;;
-    *)                  MACHINE="UNKNOWN"
-esac
+    # Verify operating system is supported...
+    case "${UNAMEOUT}" in
+        Linux*)             MACHINE=linux;;
+        Darwin*)            MACHINE=mac;;
+        *)                  MACHINE="UNKNOWN"
+    esac
 
-if [ "$MACHINE" == "UNKNOWN" ]; then
-    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
+    if [ "$MACHINE" == "UNKNOWN" ]; then
+        echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
 
-    exit 1
+        exit 1
+    fi
+
+    # Source the ".env" file so Laravel's environment variables are available...
+    if [ -f ./.env ]; then
+        source ./.env
+    fi
+
+    # Define environment variables...
+    export APP_PORT=${APP_PORT:-80}
+    export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+    export DB_PORT=${DB_PORT:-3306}
+    export WWWUSER=${WWWUSER:-$UID}
+    export WWWGROUP=${WWWGROUP:-$(id -g)}
+
+    export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
+    export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
+    export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+
+    # Ensure that Docker is running...
+    if ! docker info > /dev/null 2>&1; then
+        echo -e "${WHITE}Docker is not running.${NC}" >&2
+
+        exit 1
+    fi
+
+    # Determine if Sail is currently up...
+    PSRESULT="$(docker-compose ps -q)"
+
+    if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+        echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
+
+        docker-compose down > /dev/null 2>&1
+
+        EXEC="no"
+    elif [ -n "$PSRESULT" ]; then
+        EXEC="yes"
+    else
+        EXEC="no"
+    fi
+
+    # Function that outputs Sail is not running...
+    function sail_is_not_running {
+        echo -e "${WHITE}Sail is not running.${NC}" >&2
+        echo "" >&2
+        echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+
+        exit 1
+    }
 fi
-
-# Source the ".env" file so Laravel's environment variables are available...
-if [ -f ./.env ]; then
-    source ./.env
-fi
-
-# Define environment variables...
-export APP_PORT=${APP_PORT:-80}
-export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
-export DB_PORT=${DB_PORT:-3306}
-export WWWUSER=${WWWUSER:-$UID}
-export WWWGROUP=${WWWGROUP:-$(id -g)}
-
-export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
-export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
-export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
-
-# Ensure that Docker is running...
-if ! docker info > /dev/null 2>&1; then
-    echo -e "${WHITE}Docker is not running.${NC}" >&2
-
-    exit 1
-fi
-
-# Determine if Sail is currently up...
-PSRESULT="$(docker-compose ps -q)"
-
-if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
-    echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
-
-    docker-compose down > /dev/null 2>&1
-
-    EXEC="no"
-elif [ -n "$PSRESULT" ]; then
-    EXEC="yes"
-else
-    EXEC="no"
-fi
-
-# Function that outputs Sail is not running...
-function sail_is_not_running {
-    echo -e "${WHITE}Sail is not running.${NC}" >&2
-    echo "" >&2
-    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
-
-    exit 1
-}
 
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...

--- a/bin/sail
+++ b/bin/sail
@@ -41,31 +41,33 @@ if [ -z "${SAIL_CUSTOM}" ]; then
 
         exit 1
     fi
-
-    # Determine if Sail is currently up...
-    PSRESULT="$(docker-compose ps -q)"
-
-    if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
-        echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
-
-        docker-compose down > /dev/null 2>&1
-
-        EXEC="no"
-    elif [ -n "$PSRESULT" ]; then
-        EXEC="yes"
-    else
-        EXEC="no"
-    fi
-
-    # Function that outputs Sail is not running...
-    function sail_is_not_running {
-        echo -e "${WHITE}Sail is not running.${NC}" >&2
-        echo "" >&2
-        echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
-
-        exit 1
-    }
 fi
+
+unset SAIL_CUSTOM
+
+# Determine if Sail is currently up...
+PSRESULT="$(docker-compose ps -q)"
+
+if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+    echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
+
+    docker-compose down > /dev/null 2>&1
+
+    EXEC="no"
+elif [ -n "$PSRESULT" ]; then
+    EXEC="yes"
+else
+    EXEC="no"
+fi
+
+# Function that outputs Sail is not running...
+function sail_is_not_running {
+    echo -e "${WHITE}Sail is not running.${NC}" >&2
+    echo "" >&2
+    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+
+    exit 1
+}
 
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...

--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -48,7 +48,7 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
             ], ['sail', 'sail-docker']);
 
             $this->publishes([
-                __DIR__ . '/../bin/sail' => $this->app->basePath('sail'),
+                __DIR__ . '/../bin/publish-sail' => $this->app->basePath('sail'),
             ], ['sail', 'sail-bin']);
         }
     }


### PR DESCRIPTION
When we publish the sail script, the whole script is copied from vendor to our project root directory. So after that, if the package was updated, we will lose the changes/new features from the original script. An alternative is change the last line of the published sail to point to the vendor script, but in that case, every time we run a command that is not exist in the root sail script, the code about export variables, docker checks will run twice, since they are present in the beginning of both scripts.

So, this PR proposes adding a specific script to publish, already configured with a "**config**" command that install composer dependencies and creates a copy of the `.env`, if the file doesn't exist, which is useful when we clone a project that uses Sail (as the documentation points out [here](https://laravel.com/docs/8.x/sail#installing-composer-dependencies-for-existing-projects)). The script also comes with "**first-custom**" and "**second-custom**" options as examples of how to create custom commands. Besides that, the whole part of the original sail script that is responsible to prepare the environment and checks was placed inside an if statement that checks if it is the published sail that calls the original one.
