### PR TITLE
[1.x] Removes hardcoded service name from APP_URL in dusk and dusk:fails command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -139,7 +139,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                -e "APP_URL=http://laravel.test" \
+                -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
                 php artisan dusk "$@"
@@ -154,7 +154,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                -e "APP_URL=http://laravel.test" \
+                -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
                 php artisan dusk:fails "$@"


### PR DESCRIPTION
The `sail dusk` and `sail dusk:fails` currently have the `APP_URL` value hard coded to http://laravel.test, this replaces the hard code with a reference to `$APP_SERVICE`.

Issue reported here: https://github.com/laravel/sail/issues/212