### PR TITLE
Adding extra_hosts to the compose file stubs for automatic host.docker.internal mapping

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -8,6 +8,8 @@ services:
             args:
                 WWWGROUP: '${WWWGROUP}'
         image: sail-8.0/app
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
         ports:
             - '${APP_PORT:-80}:80'
         environment:


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Fantastic implementation of xdebug 3.0 by `Nick Haynes` in PR [#209], I think it's very pertinent to have the option of a step debugger built into the container.

However, in the PR description, which has even been approved and merged, `Nick Haynes` cites the issue that `host.docker.internal` is not available in containers running in linux environments, and the fact that users of this OS have to update the environment variable in their projects using the command below:

```
docker inspect -f {{range.NetworkSettings.Networks}}{{.Gateway}}{{end}} <container-name>
```
However, I would like to make a small contribution, which I believe is valid, as it will bring greater compatibility between Windows, Mac and Linux environments, so that we do not need extra commands to detect the IP of the `Host` machine.

The version used in the template (docker-compose.stub) of sail already supports the addition of hostname mappings, with this we were able to solve the `host.docker.internal` issue no longer needing the use of extra commands to detect the IP address of the host machine. For this we can add the option `extra_hosts` to the service where we create the application container, so we will be adding a mapping for `host.docker.internal` pointing to the host machine.

```yml
extra_hosts:
    - 'host.docker.internal:host-gateway'
```

More information about the `extra_hosts` option can be found in the documentation at [compose-file#extra_hosts](https://docs.docker.com/compose/compose-file/compose-file-v3/#extra_hosts)

A small change that would have value. The `laravel.test` service would look like this:

```yml
laravel.test:
    build:
        context: ./vendor/laravel/sail/runtimes/8.0
        dockerfile: Dockerfile
        args:
            WWWGROUP: '${WWWGROUP}'
    image: sail-8.0/app
    extra_hosts:
        - 'host.docker.internal:host-gateway'
    networks:
        - sail
    ports:
        - '${APP_PORT:-80}:80'
    environment:
        WWWUSER: '${WWWUSER}'
        LARAVEL_SAIL: 1
        XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
        XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
    volumes:
        - '.:/var/www/html'
    depends_on:
        - mysql
        - redis
```

With this, every time we create/start the application container the `host.docker.internal` mapping will be created and will point to the host machine. Inside the container in your `/etc/hosts` file, the appropriate appointment records will be created, as shown in the example below:

```
127.0.0.1       localhost
::1             localhost ip6-localhost ip6-loopback
fe00::0         ip6-localnet
ff00::0         ip6-mcastprefix
ff02::1         ip6-allnodes
ff02::2         ip6-allrouters
172.17.0.1      host.docker.internal
```
