### PR TITLE
Enclose default XDEBUG_MODE in quotes

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -15,7 +15,7 @@ services:
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
-            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-"off"}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
         volumes:
             - '.:/var/www/html'


### PR DESCRIPTION
Currently, the default value of XDEBUG_MODE is set to the unquoted value `off`. This causes the docker yaml parser to parse the value `off` as the boolean `false`. Due to this xdebug will display an error each time that it's initialized, see the image below:
![image](https://user-images.githubusercontent.com/17050455/131886872-998a8745-e5c1-4a98-914d-6bf442f11f3e.png)

In order to fix this, the value `off` should be enclosed by strings as mentioned in [the docker-compose v3 spec](https://docs.docker.com/compose/compose-file/compose-file-v3/): "YAML boolean values ("true", "false", "yes", "no", "on", "off") must be enclosed in quotes, so that the parser interprets them as strings."