### PR TITLE
Revert quoted XDEBUG_MODE environment variable

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -15,7 +15,7 @@ services:
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
-            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-"off"}'
+            XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
         volumes:
             - '.:/var/www/html'


### PR DESCRIPTION
This PR reverts https://github.com/laravel/sail/pull/231 because the quotes around the default value are making Xdebug complain about an invalid value:

With `XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-"off"}'` the quotes are being included in the string itself:

![Screen Shot 2021-09-03 at 10 28 47](https://user-images.githubusercontent.com/5356595/132031244-76593644-1d68-4352-9ad9-85eee0da175d.png)

With `XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'` it doesn't trigger the error and passes the right `off` (unquoted) string to Xdebug:

![Screen Shot 2021-09-03 at 10 29 47](https://user-images.githubusercontent.com/5356595/132031288-efe4020d-f523-4155-8839-c3f306f452e0.png)

This kind of make sense given that the string interpolation already happens inside single quotes? `XDEBUG_MODE: '${...}'`

Not sure if this behavior is different across docker versions so I'll include mine:

OS: MacOS 11.4
Docker version: 20.10.7, build f0df350
Sail version: v1.10.1