### PR TITLE
Implementation of an option to disable the pseudo-tty allocation

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -23,7 +23,7 @@ if [ -f ./.env ]; then
     source ./.env
 fi
 
-if [ -z "$SAIL_SET_TTY" ] || [ "$SAIL_SET_TTY" != "1" ] ; then
+if [ -z "$SAIL_TTY" ] || [ "$SAIL_TTY" != "1" ] ; then
     TTY=""
 else
     TTY="-T"

--- a/bin/sail
+++ b/bin/sail
@@ -19,7 +19,6 @@ if [ "$MACHINE" == "UNKNOWN" ]; then
 fi
 
 # Source the ".env" file so Laravel's environment variables are available...
-
 if [ -f ./.env ]; then
     source ./.env
 fi

--- a/bin/sail
+++ b/bin/sail
@@ -19,11 +19,12 @@ if [ "$MACHINE" == "UNKNOWN" ]; then
 fi
 
 # Source the ".env" file so Laravel's environment variables are available...
+
 if [ -f ./.env ]; then
     source ./.env
 fi
 
-if [ -z "$SAIL_SET_TTY" ] || [ "$SAIL_SET_TTY" != "y" ] ; then
+if [ -z "$SAIL_SET_TTY" ] || [ "$SAIL_SET_TTY" != "1" ] ; then
     TTY=""
 else
     TTY="-T"

--- a/bin/sail
+++ b/bin/sail
@@ -23,6 +23,12 @@ if [ -f ./.env ]; then
     source ./.env
 fi
 
+if [ -z "$SAIL_SET_TTY" ] || [ "$SAIL_SET_TTY" != "y" ] ; then
+    TTY=""
+else
+    TTY="-T"
+fi
+
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
@@ -76,6 +82,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 php "$@"
         else
@@ -89,6 +96,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 ./vendor/bin/"$@"
         else
@@ -102,6 +110,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 composer "$@"
         else
@@ -115,6 +124,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 php artisan "$@"
         else
@@ -128,6 +138,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 -e XDEBUG_SESSION=1 \
                 "$APP_SERVICE" \
                 php artisan "$@"
@@ -142,6 +153,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 php artisan test "$@"
         else
@@ -155,6 +167,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -170,6 +183,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -185,6 +199,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 php artisan tinker
         else
@@ -198,6 +213,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 node "$@"
         else
@@ -211,6 +227,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 npm "$@"
         else
@@ -224,6 +241,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 npx "$@"
         else
@@ -237,6 +255,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 yarn "$@"
         else
@@ -249,6 +268,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
+                $TTY \
                 mysql \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -261,6 +281,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
+                $TTY \
                 mariadb \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -273,6 +294,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
+                 $TTY \
                  pgsql \
                  bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
@@ -286,6 +308,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
+                $TTY \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -298,6 +321,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
+                $TTY \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -310,6 +334,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
+                $TTY \
                 redis \
                 redis-cli
         else


### PR DESCRIPTION
In the context of deploying my code, I would like to use Sail to run various tests etc. Currently, however, this fails in places due to the execution of commands and the error message `the input device is not a TTY`. By adding the parameter `-T` to the execution of docker-compose via `export SAIL_SET_TTY=y`, this error no longer occurs.