### PR TITLE
[1.x] Environment variable for share subdomain.

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -39,6 +39,7 @@ export WWWGROUP=${WWWGROUP:-$(id -g)}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -350,7 +351,7 @@ if [ $# -gt 0 ]; then
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
-            --subdomain="" \
+            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
             "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
Sometime you need always use one domain in project tests.

.env | option | result subdomain
--- | --- | ---
None | None | Random
None | from-option | from-option
from-env | None | from-env
from-env | from-option | from-option

rel. #170

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
