### PR TITLE
Revert "Implementation of an option to disable the pseudo-tty allocation"

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -23,12 +23,6 @@ if [ -f ./.env ]; then
     source ./.env
 fi
 
-if [ -z "$SAIL_TTY" ] || [ "$SAIL_TTY" != "1" ] ; then
-    TTY=""
-else
-    TTY="-T"
-fi
-
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
@@ -83,7 +77,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 php "$@"
         else
@@ -97,7 +90,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 ./vendor/bin/"$@"
         else
@@ -111,7 +103,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 composer "$@"
         else
@@ -125,7 +116,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 php artisan "$@"
         else
@@ -139,7 +129,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 -e XDEBUG_SESSION=1 \
                 "$APP_SERVICE" \
                 php artisan "$@"
@@ -154,7 +143,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 php artisan test "$@"
         else
@@ -168,7 +156,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -184,7 +171,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
                 "$APP_SERVICE" \
@@ -200,7 +186,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 php artisan tinker
         else
@@ -214,7 +199,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 node "$@"
         else
@@ -228,7 +212,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 npm "$@"
         else
@@ -242,7 +225,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 npx "$@"
         else
@@ -256,7 +238,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 yarn "$@"
         else
@@ -269,7 +250,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                $TTY \
                 mysql \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -282,7 +262,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                $TTY \
                 mariadb \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -295,7 +274,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                 $TTY \
                  pgsql \
                  bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
@@ -309,7 +287,6 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                $TTY \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -322,7 +299,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                $TTY \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -335,7 +311,6 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                $TTY \
                 redis \
                 redis-cli
         else


### PR DESCRIPTION
Reverts laravel/sail#236

Because flag `-T` in `docker-compose exec` disable TTY and broken commands like `sail php`, `sail tinker`, `sail node` etc. which are waiting for user input. They wait infinit. And disable colorize in other commands.

It is necessary to understand the problem in detail and a more precise solution for laravel/sail#236.