### PR TITLE
[1.x] Fixed version of expose

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -34,6 +34,7 @@ export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
 export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
+export SAIL_SHARE_VERSION=${SAIL_SHARE_VERSION:-"latest"}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -322,7 +323,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:$SAIL_SHARE_VERSION share http://host.docker.internal:"$APP_PORT" \
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \


### PR DESCRIPTION
Sometimes problems can arise due to using different client and server versions. [This has already happened](https://github.com/laravel/sail/pull/170) when expose updated to version 2.
I suggest using the server version of larave-sail.site as the client's default version. For those who want to use selfhosted expose, the version can be changed in `.env`

Perhaps the idea is more clearly described [here](https://github.com/laravel/sail/issues/216#issuecomment-923883726).

## Before merge
Please replace `latest` in default `SAIL_SHARE_VERSION` with laravel-sail.site expose version.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
