### PR TITLE
Change minio volume directory

### DIFF
--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -7,10 +7,10 @@
             MINIO_ROOT_USER: 'sail'
             MINIO_ROOT_PASSWORD: 'password'
         volumes:
-            - 'sailminio:/data/minio'
+            - 'sailminio:/data'
         networks:
             - sail
-        command: minio server /data/minio --console-address ":8900"
+        command: minio server /data --console-address ":8900"
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
             retries: 3


### PR DESCRIPTION
For some reason, using /data/minio causes the Minio container to create a second volume with a random name.

By switching back to the Minio default of /data, this problem is eliminated