### PR TITLE
alias the usage of docker-compose with the compose cli plugin if docker-compose can not be executed

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if ! [ -x "$(command -v docker-compose)" ]; then
+    shopt -s expand_aliases
+    alias docker-compose='docker compose'
+fi
+
 UNAMEOUT="$(uname -s)"
 
 WHITE='\033[1;37m'


### PR DESCRIPTION
Since the `compose` docker cli plugin is now released I was not able to use the sail cli any longer.
This pull request conditionally tries to alias the docker-compose command with the usage of the respective cli plugin and lets docker continue to be responsible for reporting whether it is installed or not.


