### PR TITLE
Add option to run a container with a queue worker

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -58,6 +58,7 @@ class InstallCommand extends Command
              'mysql',
              'pgsql',
              'mariadb',
+             'queue',
              'redis',
              'memcached',
              'meilisearch',
@@ -77,7 +78,7 @@ class InstallCommand extends Command
     {
         $depends = collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio', 'selenium']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'queue', 'redis', 'meilisearch', 'minio', 'selenium']);
             })->map(function ($service) {
                 return "            - {$service}";
             })->whenNotEmpty(function ($collection) {
@@ -125,6 +126,8 @@ class InstallCommand extends Command
             $environment = str_replace('DB_PORT=3306', "DB_PORT=5432", $environment);
         } elseif (in_array('mariadb', $services)) {
             $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mariadb", $environment);
+        } elseif (in_array('queue', $services) && in_array('redis', $services)) {
+            $environment = str_replace('QUEUE_CONNECTION=sync', 'QUEUE_CONNECTION=redis', $environment);
         } else {
             $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mysql", $environment);
         }

--- a/stubs/queue.stub
+++ b/stubs/queue.stub
@@ -1,0 +1,15 @@
+    queue:
+        build:
+            context: ./vendor/laravel/sail/runtimes/8.0
+            dockerfile: Dockerfile
+            args:
+                WWWGROUP: '${WWWGROUP}'
+        image: sail-8.0/app
+        environment:
+            WWWUSER: '${WWWUSER}'
+            LARAVEL_SAIL: 1
+        volumes:
+            - '.:/var/www/html'
+        networks:
+            - sail
+        command: php artisan queue:listen


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

As mentioned in #245, I think it would be a nice addition to have a queue worker container included.

This container runs the `artisan queue:listen` command. When `redis` is also included in the install, then the queue connection is automatically set to redis.

I'm curious to hear any feedback.