### PR TITLE
Ability to set different services for commands

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -31,6 +31,8 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_SERVICE_PHP=${APP_SERVICE_PHP:-$APP_SERVICE}
+export APP_SERVICE_JS=${APP_SERVICE_JS:-$APP_SERVICE}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
@@ -82,7 +84,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php "$@"
         else
             sail_is_not_running
@@ -95,7 +97,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "$APP_SERVICE_PHP" \
                 ./vendor/bin/"$@"
         else
             sail_is_not_running
@@ -108,7 +110,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 composer "$@"
         else
             sail_is_not_running
@@ -121,7 +123,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan "$@"
         else
             sail_is_not_running
@@ -135,7 +137,7 @@ if [ $# -gt 0 ]; then
             docker-compose exec \
                 -u sail \
                 -e XDEBUG_SESSION=1 \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan "$@"
         else
             sail_is_not_running
@@ -148,7 +150,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan test "$@"
         else
             sail_is_not_running
@@ -161,9 +163,9 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
+                -e "APP_URL=http://${APP_SERVICE_PHP}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan dusk "$@"
         else
             sail_is_not_running
@@ -176,9 +178,9 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
+                -e "APP_URL=http://${APP_SERVICE_PHP}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan dusk:fails "$@"
         else
             sail_is_not_running
@@ -191,7 +193,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_PHP}" \
                 php artisan tinker
         else
             sail_is_not_running
@@ -204,7 +206,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_JS}" \
                 node "$@"
         else
             sail_is_not_running
@@ -217,7 +219,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_JS}" \
                 npm "$@"
         else
             sail_is_not_running
@@ -230,7 +232,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_JS}" \
                 npx "$@"
         else
             sail_is_not_running
@@ -243,7 +245,7 @@ if [ $# -gt 0 ]; then
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
                 -u sail \
-                "$APP_SERVICE" \
+                "${APP_SERVICE_JS}" \
                 yarn "$@"
         else
             sail_is_not_running


### PR DESCRIPTION
Usually, `sail`'s commands are executed in one container, but when the project's `php` and `js` are executed in different ones, it was not possible to specify which one. I propose to add two variables `APP_SERVICE_PHP` and `APP_SERVICE_JS` in backward compatibility mode with `APP_SERVICE`. Thanks!