### PR TITLE
Ensure "sail build" always uses the latest intended docker images

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -337,6 +337,17 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Ensure docker uses the very latest declared docker images
+    elif [ "$1" == "build" ] ; then
+       # This will pull all the regular (non build) related images
+       # that are declared in docker-compose.yml
+       # we ignore failures to prevent offline pull errors, allowing cached images
+       docker-compose pull --ignore-pull-failures --quiet 2> /dev/null
+
+       # Force pull checks for any Dockerfiles declared images
+       docker-compose "$@" --pull
+
+
     # Pass unknown commands to the "docker-compose" binary...
     else
         docker-compose "$@"


### PR DESCRIPTION
# The problem

I spent countless hours trying to understand why `./sail build` which is ultimately just `docker-compose build` was failing with: 
```

Your distribution, identified as "Ubuntu Hirsute Hippo (development branch)", 
is a pre-release version of Ubuntu. NodeSource does not maintain 
official support for Ubuntu versions until they are formally released. 

You can try using the manual installation instructions 
available at https://github.com/nodesource/distributions 
and use the latest supported Ubuntu version 
name as the distribution identifier, although this is not guaranteed to work.
```

`ERROR: Service 'laravel.test' failed to build : Build failed`


#  The cause

```
&& curl -sL https://deb.nodesource.com/setup_16.x | bash - \
&& apt-get install -y nodejs \
```

The `setup_16.x` script has this check: 

```
IS_PRERELEASE=$(lsb_release -d | grep 'Ubuntu .*development' >& /dev/null; echo $?)
if [[ $IS_PRERELEASE -eq 0 ]]; then
    print_status "Your distribution, identified as \"$(lsb_release -d -s)\", is a pre-release version of Ubuntu. NodeSource does not maintain official support for Ubuntu versions until they are formally released. You can try using the manual installation instructions available at https://github.com/nodesource/distributions and use the latest supported Ubuntu version name as the distribution identifier, although this is not guaranteed to work."
    exit 1
fi
```

My locally cached image of ubuntu:21.04 (ubuntu:hirsute-20210602) was returning 
```
root@46e1259b0794:/# /usr/bin/lsb_release -d
Description:	Ubuntu Hirsute Hippo (development branch)
```

Where as the current up-to-date image returns:
```
root@eab0884adfaf:/# lsb_release -d
Description:	Ubuntu 21.04
```

# Tests / reproduce 
To experience the problem, download an earlier image and tag it as ubuntu:21.04 to simulate a cached docker image
```

docker pull ubuntu:hirsute-20210602 
docker tag ubuntu:hirsute-20210602 ubuntu:21.04
./sail build --no-cache

```

To test what this patch is intended to fix, run the same commands above with my fix.

# Fixes

## The simple fix for building
`sail build --no-cache --pull` 
However, this doesn't pull the latest service images declared in the docker-compose.yml such as mysql.

## Full fix with docker-compose
Pull the latest image by using `docker-compose pull` for the services listed in docker-compose.yml and `docker-compose build --pull` for those that are required for building.

# Why hook into the `sail build` 
I naturally assumed `--no-cache` meant just that (including any images), but it's referring to the build process alone and not the docker images contained within. Using cached images along side pulling external scripts during the build could create problems in the future if they don't match. 

If the Dockerfile says use ubuntu:21.04, then I feel it's important to check we have the intended version. 

Possible alternatives:
1. Set the exact version of the image tag, including any external install scripts into the source but that would require addition maintenance for every release.
2. Provide better documentation around this issue. 
3. Add a `sail image-update`


### Additional tests for lsb-release output
```
docker run --rm -e DEBIAN_FRONTEND=noninteractive -e TZ=UTC -it ubuntu:hirsute-20210602 
apt update && apt install -y lsb-release
lsb_release -d
```



