### PR TITLE
Mimic behvaiour of phpdotenv for .env files

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -28,6 +28,11 @@ if [ -f ./.env ]; then
     source ./.env
 fi
 
+# Check to see if an APP_ENV specific ".env" file exists to mimic the behaviour of phpdotenv...
+if [ -f ./.env.$APP_ENV ]; then
+    source ./.env.$APP_ENV
+fi
+
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
@@ -339,7 +344,12 @@ if [ $# -gt 0 ]; then
 
     # Pass unknown commands to the "docker-compose" binary...
     else
-        docker-compose "$@"
+        if [ -f ./.env.$APP_ENV ]; then
+        # Povide an APP_ENV specific ".env" file to docker-compose to mimic the behaviour of phpdotenv...
+            docker-compose --env-file .env.$APP_ENV "$@"
+        else
+            docker-compose "$@"
+        fi
     fi
 else
     docker-compose ps


### PR DESCRIPTION
Sail binary checks for any .env.$APP_ENV files and loads them and provides them to docker compose to get the same behaviour as the running application.

e.g. If .env and .env.local exist with different DB credentials then currently docker compose will configure the DB container with the credentials in .env, when the app is run it will use the credentials in .env.local and an SQL username/password error will be thrown.
