### PR TITLE
[1.x] Supervisor: multiple processes without Sail publish.

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -48,7 +48,7 @@ RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY supervisord.conf /etc/supervisor/conf.d/50-supervisord.conf
 COPY php.ini /etc/php/7.4/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 

--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ];then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
 fi

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -1,9 +1,3 @@
-[supervisord]
-nodaemon=true
-user=root
-logfile=/var/log/supervisor/supervisord.log
-pidfile=/var/run/supervisord.pid
-
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -48,7 +48,7 @@ RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY supervisord.conf /etc/supervisor/conf.d/50-supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ];then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
 fi

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -1,9 +1,3 @@
-[supervisord]
-nodaemon=true
-user=root
-logfile=/var/log/supervisor/supervisord.log
-pidfile=/var/run/supervisord.pid
-
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -49,7 +49,7 @@ RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY supervisord.conf /etc/supervisor/conf.d/50-supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ];then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf
 fi

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -1,9 +1,3 @@
-[supervisord]
-nodaemon=true
-user=root
-logfile=/var/log/supervisor/supervisord.log
-pidfile=/var/run/supervisord.pid
-
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail


### PR DESCRIPTION
## Problem
If you need run `cron` or `horizon` or any process all time, you must publish sail runtime directory and change `supervisord.conf`
## Solution
Append `docker-compose.override.yml` with config:
```yaml
version: '3'
services:
    laravel.test:
        volumes:
            - './docker/php/cron.conf:/etc/supervisor/conf.d/51-cron.conf'
            - './docker/php/horizon.conf:/etc/supervisor/conf.d/52-horizon.conf'
```
And run `supervisord` with native config but not Sail's custom. Because native config run all configs from `conf.d`
## Changes
Deleting default `supervisord` configs because this exists in `/etc/supervisor/supervisord.conf` and `nodaemon` appends in `start-container` script
```diff
- [supervisord]
- nodaemon=true
- user=root
- logfile=/var/log/supervisor/supervisord.log
- pidfile=/var/run/supervisord.pid
```

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
