### PR TITLE
Update stub for arm image

### DIFF
--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -1,13 +1,14 @@
     mysql:
-        image: 'mysql:8.0'
+        image: 'mysql/mysql-server:8.0'
         ports:
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: "%"
             MYSQL_DATABASE: '${DB_DATABASE}'
             MYSQL_USER: '${DB_USERNAME}'
             MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+            MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - 'sailmysql:/var/lib/mysql'
         networks:


### PR DESCRIPTION
This updates the MySQL stub to use the official `mysql/mysql-server` image which has an ARM build that works on Apple Silicon without needing a `platform` directive in your `docker-compose.yml` file.