### PR TITLE
[1.x] Fix NODE_VERSION on build.

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -3,12 +3,12 @@ FROM ubuntu:21.04
 LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
+ARG NODE_VERSION=16
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
-ENV NODE_VERSION=16
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -3,12 +3,12 @@ FROM ubuntu:21.04
 LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
+ARG NODE_VERSION=16
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
-ENV NODE_VERSION=16
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -3,12 +3,12 @@ FROM ubuntu:21.04
 LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
+ARG NODE_VERSION=16
 
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
-ENV NODE_VERSION=16
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 


### PR DESCRIPTION
If `NODE_VERSION` declared as `ENV` variable and overwritten in `docker-compose.yml`, new value is not available in build.
It's must be declared as `ARG` and overwritten in `build.args` section on the service.
Ref: laravel/sail#261
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
