### PR TITLE
[1.x] Add missing spaces before `then` keywords

### DIFF
--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -10,7 +10,7 @@ fi
 
 chmod -R ugo+rw /.composer
 
-if [ $# -gt 0 ];then
+if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
     /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -10,7 +10,7 @@ fi
 
 chmod -R ugo+rw /.composer
 
-if [ $# -gt 0 ];then
+if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
     /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -10,7 +10,7 @@ fi
 
 chmod -R ugo+rw /.composer
 
-if [ $# -gt 0 ];then
+if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
     /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Just giving this keywords some room to breathe as the ones above them to keep the whole file consistent.