### PR TITLE
Support for Laravel ^7.0?

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/contracts": "^8.0|^9.0",
-        "illuminate/console": "^8.0|^9.0",
-        "illuminate/support": "^8.0|^9.0"
+        "illuminate/contracts": "^7.0|^8.0|^9.0",
+        "illuminate/console": "^7.0|^8.0|^9.0",
+        "illuminate/support": "^7.0|^8.0|^9.0"
     },
     "bin": [
         "bin/sail"


### PR DESCRIPTION
I have an older project that I can't upgrade to Laravel 8 yet (for reasons that I won't burden you with). Is there any particular reason we can't expand the dependencies here to include 7.0 contracts, console, or support modules? I was looking through the codebase quickly, and I haven't found any direct dependencies.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
