### PR TITLE
[1.x] Added "websockets" integration

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -39,6 +39,7 @@ class InstallCommand extends Command
 
         $this->buildDockerCompose($services);
         $this->replaceEnvVariables($services);
+        $this->updateConfigs($services);
 
         if ($this->option('devcontainer')) {
             $this->installDevContainer();

--- a/stubs/broadcasting-config.stub
+++ b/stubs/broadcasting-config.stub
@@ -1,0 +1,67 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_DRIVER', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over websockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
+    'connections' => [
+
+        'pusher' => [
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY', 'local-app-key'),
+            'secret' => env('PUSHER_APP_SECRET', 'local-app-secret'),
+            'app_id' => env('PUSHER_APP_ID', 'local-app-id'),
+            'options' => [
+                'host' => env('PUSHER_HOST', 'websockets'),
+                'port' => env('PUSHER_PORT', 6001),
+                'scheme' => env('PUSHER_SCHEME', 'http'),
+                'encrypted' => true,
+                'useTLS' => env('PUSHER_SCHEME') === 'https',
+            ],
+        ],
+
+        'ably' => [
+            'driver' => 'ably',
+            'key' => env('ABLY_KEY'),
+        ],
+
+        'redis' => [
+            'driver' => 'redis',
+            'connection' => 'default',
+        ],
+
+        'log' => [
+            'driver' => 'log',
+        ],
+
+        'null' => [
+            'driver' => 'null',
+        ],
+
+    ],
+
+];

--- a/stubs/websockets.stub
+++ b/stubs/websockets.stub
@@ -1,8 +1,7 @@
     websockets:
         image: 'quay.io/soketi/soketi:latest-16-alpine'
         ports:
-            - '${FORWARD_WEBSOCKETS_PORT:-9000}:9000'
-            - '${FORWARD_WEBSOCKETS_CONSOLE_PORT:-8900}:8900'
+            - '${FORWARD_WEBSOCKETS_PORT:-6001}:6001'
         environment:
             DEFAULT_APP_ID: 'local-app-id'
             DEFAULT_APP_KEY: 'local-app-key'

--- a/stubs/websockets.stub
+++ b/stubs/websockets.stub
@@ -1,0 +1,17 @@
+    websockets:
+        image: 'quay.io/soketi/soketi:latest-16-alpine'
+        ports:
+            - '${FORWARD_WEBSOCKETS_PORT:-9000}:9000'
+            - '${FORWARD_WEBSOCKETS_CONSOLE_PORT:-8900}:8900'
+        environment:
+            DEFAULT_APP_ID: 'local-app-id'
+            DEFAULT_APP_KEY: 'local-app-key'
+            DEFAULT_APP_SECRET: 'local-app-secret'
+            DEFAULT_APP_ENABLE_CLIENT_MESSAGES: '1'
+        networks:
+            - sail
+        command: node /app/bin/server.js start
+        healthcheck:
+            test: ["CMD", "curl", "-f", "http://localhost:6001"]
+            retries: 3
+            timeout: 5s


### PR DESCRIPTION
Initially, I've been [submitting a PR](https://github.com/laravel/docs/pull/7431) to update the broadcasting docs to add [soketi/soketi](https://github.com/soketi/soketi) as another open-source alternative for broadcasting. This came after the Socket.IO support was dropped, so it's fully compatible with it.

This PR adds a new `websockets` option for Sail to automatically deploy a Pusher-compatible WebSockets server in Sail. The app, even if it's 0.x, it's already thoroughly tested and makes a good companion for development, at least. I thought that might be a good option to avoid setting it up yourself. :)

Not sure how to handle the `broadcasting.php` file edit as it requires some new options to be set to the `pusher` broadcaster. I have just decided to get the original Laravel `config/broadcasting.php`.

[soketi's documentation on manual Sail instalation](https://rennokki.gitbook.io/soketi-docs/getting-started/installation/laravel-sail-docker)