### PR TITLE
Check environment variable flag to enforce use docker compose cli plugin

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if ! [ -x "$(command -v docker-compose)" ]; then
+if [ ! -z "$SAIL_USE_COMPOSE_CLI_PLUGIN" ] || [ ! -x "$(command -v docker-compose)" ]; then
     shopt -s expand_aliases
     alias docker-compose='docker compose'
 fi


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

This PR addresses issue https://github.com/laravel/sail/issues/293.

We don't have a way to enforce docker compose cli plugin usage if both `docker-compose` (v1) and docker compose cli plugin (v2) are installed.

I named the environment variable `SAIL_USE_COMPOSE_CLI_PLUGIN` and I'll change it if better alternatives will be proposed. 

Also, I'm not an expert on bash scripting; if there is a better `if` syntax please let me know. This is first checking for the environment variable, thus it will run faster when the variable is set (it wont execute the `command -v docker-compose`).

PS: If this gets merged, I think it needs to be documented but I'm not very familiar with the docs/site structure.