### PR TITLE
Set meilisearch data path

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -3,6 +3,8 @@
         platform: linux/x86_64
         ports:
             - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+        environment:
+            MEILI_DB_PATH: '/data.ms'
         volumes:
             - 'sailmeilisearch:/data.ms'
         networks:


### PR DESCRIPTION
MeiliSearch v0.24 had a breaking change and moved the database folder 
from `/data.ms` to `/home/meili/data.ms`, so to keep using `/data.ms`, we 
need to set the `MEILI_DB_PATH` environment variable. This also avoids
trouble in the future when the data might move again, inside `/var`.

Refs:
- Release notes: https://github.com/meilisearch/MeiliSearch/releases/tag/v0.24.0
- Issue: https://github.com/meilisearch/MeiliSearch/issues/1969