### PR TITLE
[1.x] Revert "Set meilisearch data path"

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -3,8 +3,6 @@
         platform: linux/x86_64
         ports:
             - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
-        environment:
-            MEILI_DB_PATH: '/data.ms'
         volumes:
             - 'sailmeilisearch:/data.ms'
         networks:


### PR DESCRIPTION
Reverts laravel/sail#299

Reverting this because it causes Sail to throw permissions errors: https://github.com/laravel/sail/issues/300