### PR TITLE
Change sail docker-compose default file

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -58,11 +58,11 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     fi
 
     # Determine if Sail is currently up...
-    PSRESULT="$(docker-compose ps -q)"
-    if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+    PSRESULT="$(docker-compose -f docker-compose.sail.yml ps -q)"
+    if docker-compose -f docker-compose.sail.yml ps | grep $APP_SERVICE | grep 'Exit'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down > /dev/null 2>&1
+        docker-compose -f docker-compose.sail.yml down > /dev/null 2>&1
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -80,7 +80,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php "$@"
@@ -93,7 +93,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 ./vendor/bin/"$@"
@@ -106,7 +106,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 composer "$@"
@@ -119,7 +119,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan "$@"
@@ -132,7 +132,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 -e XDEBUG_SESSION=1 \
                 "$APP_SERVICE" \
@@ -146,7 +146,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan test "$@"
@@ -159,7 +159,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -174,7 +174,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -189,7 +189,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan tinker
@@ -202,7 +202,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 node "$@"
@@ -215,7 +215,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 npm "$@"
@@ -228,7 +228,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 npx "$@"
@@ -241,7 +241,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 yarn "$@"
@@ -254,7 +254,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 mysql \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -266,7 +266,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 mariadb \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -278,7 +278,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                  pgsql \
                  bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
@@ -290,7 +290,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 -u sail \
                 "$APP_SERVICE" \
                 bash "$@"
@@ -303,7 +303,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -315,7 +315,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f docker-compose.sail.yml exec \
                 redis \
                 redis-cli
         else
@@ -339,8 +339,8 @@ if [ $# -gt 0 ]; then
 
     # Pass unknown commands to the "docker-compose" binary...
     else
-        docker-compose "$@"
+        docker-compose -f docker-compose.sail.yml "$@"
     fi
 else
-    docker-compose ps
+    docker-compose -f docker-compose.sail.yml ps
 fi

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -111,7 +111,7 @@ class InstallCommand extends Command
         // Remove empty lines...
         $dockerCompose = preg_replace("/(^[\r\n]*|[\r\n]+)[\s\t]*[\r\n]+/", "\n", $dockerCompose);
 
-        file_put_contents($this->laravel->basePath('docker-compose.yml'), $dockerCompose);
+        file_put_contents($this->laravel->basePath('docker-compose.sail.yml'), $dockerCompose);
     }
 
     /**

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -30,7 +30,7 @@ class PublishCommand extends Command
         $this->call('vendor:publish', ['--tag' => 'sail-docker']);
 
         file_put_contents(
-            $this->laravel->basePath('docker-compose.yml'),
+            $this->laravel->basePath('docker-compose.sail.yml'),
             str_replace(
                 [
                     './vendor/laravel/sail/runtimes/8.1',
@@ -42,7 +42,7 @@ class PublishCommand extends Command
                     './docker/8.0',
                     './docker/7.4',
                 ],
-                file_get_contents($this->laravel->basePath('docker-compose.yml'))
+                file_get_contents($this->laravel->basePath('docker-compose.sail.yml'))
             )
         );
     }

--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -2,7 +2,7 @@
 {
 	"name": "Existing Docker Compose (Extend)",
 	"dockerComposeFile": [
-		"../docker-compose.yml"
+		"../docker-compose.sail.yml"
 	],
 	"service": "laravel.test",
 	"workspaceFolder": "/var/www/html",


### PR DESCRIPTION
## Why?
When working with Laravel project, you will never use Sail's `docker-compose.yml` directly by `docker-compose` as sail binary provides better shortcuts to type less symbols in console and have some env-variables injected from inside.

However, Sail is considered as only local development environment and there is a great chance that there will be separate production configuration (or even multiple). In such case, this will be much more comfortable to have Sail in the file that will not take place of default `docker-compose.yml`. I felt like wasted whole day typing `docker-compose -f docker-compose.prod.yml ...` when was deploying my app.

## Potential issues
* Not back compatible, can't easily composer update