### PR TITLE
Add separator between volume names

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -55,16 +55,16 @@ class InstallCommand extends Command
     protected function gatherServicesWithSymfonyMenu()
     {
         return $this->choice('Which services would you like to install?', [
-             'mysql',
-             'pgsql',
-             'mariadb',
-             'redis',
-             'memcached',
-             'meilisearch',
-             'minio',
-             'mailhog',
-             'selenium',
-         ], 0, null, true);
+            'mysql',
+            'pgsql',
+            'mariadb',
+            'redis',
+            'memcached',
+            'meilisearch',
+            'minio',
+            'mailhog',
+            'selenium',
+        ], 0, null, true);
     }
 
     /**
@@ -92,7 +92,7 @@ class InstallCommand extends Command
             ->filter(function ($service) {
                 return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
             })->map(function ($service) {
-                return "    sail{$service}:\n        driver: local";
+                return "    sail-{$service}:\n        driver: local";
             })->whenNotEmpty(function ($collection) {
                 return $collection->prepend('volumes:');
             })->implode("\n");

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -55,16 +55,16 @@ class InstallCommand extends Command
     protected function gatherServicesWithSymfonyMenu()
     {
         return $this->choice('Which services would you like to install?', [
-            'mysql',
-            'pgsql',
-            'mariadb',
-            'redis',
-            'memcached',
-            'meilisearch',
-            'minio',
-            'mailhog',
-            'selenium',
-        ], 0, null, true);
+             'mysql',
+             'pgsql',
+             'mariadb',
+             'redis',
+             'memcached',
+             'meilisearch',
+             'minio',
+             'mailhog',
+             'selenium',
+         ], 0, null, true);
     }
 
     /**

--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -4,12 +4,13 @@
             - '${FORWARD_DB_PORT:-3306}:3306'
         environment:
             MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+            MYSQL_ROOT_HOST: "%"
             MYSQL_DATABASE: '${DB_DATABASE}'
             MYSQL_USER: '${DB_USERNAME}'
             MYSQL_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         volumes:
-            - 'sailmariadb:/var/lib/mysql'
+            - 'sail-mariadb:/var/lib/mysql'
         networks:
             - sail
         healthcheck:

--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -4,7 +4,7 @@
         ports:
             - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
         volumes:
-            - 'sailmeilisearch:/data.ms'
+            - 'sail-meilisearch:/data.ms'
         networks:
             - sail
         healthcheck:

--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -7,7 +7,7 @@
             MINIO_ROOT_USER: 'sail'
             MINIO_ROOT_PASSWORD: 'password'
         volumes:
-            - 'sailminio:/data/minio'
+            - 'sail-minio:/data/minio'
         networks:
             - sail
         command: minio server /data/minio --console-address ":8900"

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -10,7 +10,7 @@
             MYSQL_PASSWORD: '${DB_PASSWORD}'
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
-            - 'sailmysql:/var/lib/mysql'
+            - 'sail-mysql:/var/lib/mysql'
         networks:
             - sail
         healthcheck:

--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -8,7 +8,7 @@
             POSTGRES_USER: '${DB_USERNAME}'
             POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
         volumes:
-            - 'sailpgsql:/var/lib/postgresql/data'
+            - 'sail-pgsql:/var/lib/postgresql/data'
         networks:
             - sail
         healthcheck:

--- a/stubs/redis.stub
+++ b/stubs/redis.stub
@@ -3,7 +3,7 @@
         ports:
             - '${FORWARD_REDIS_PORT:-6379}:6379'
         volumes:
-            - 'sailredis:/data'
+            - 'sail-redis:/data'
         networks:
             - sail
         healthcheck:


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

To normalize the names of volumes a bit, I've added separators between the two words `sail` and `service-name`.

I've also added the `MYSQL_ROOT_HOST` variable to the `mariadb` container, documented here: https://hub.docker.com/_/mariadb/
