### PR TITLE
Allow for default parameters to be sent to 'sail down' from env

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -63,7 +63,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
+        docker-compose down $SAIL_DOWN_PARAMS > /dev/null 2>&1
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -353,7 +353,7 @@ if [ $# -gt 0 ]; then
 
     # Handle the down command when no parameter string is given...
     elif [ "$1" == "down" ] && [ "$#" == "1" ]; then
-        docker-compose down $DOWN_REMOVES_VOLUMES
+        docker-compose down $SAIL_DOWN_PARAMS
 
     # Pass unknown commands to the "docker-compose" binary...
     else

--- a/bin/sail
+++ b/bin/sail
@@ -39,6 +39,7 @@ export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
 export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
+export SAIL_DOWN_PARAMS=${SAIL_DOWN_PARAMS:-""}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -48,12 +49,6 @@ function sail_is_not_running {
 
     exit 1
 }
-
-if [ -z "$SAIL_DOWN_REMOVES_VOLUMES" ]; then
-    DOWN_REMOVES_VOLUMES="--volumes"
-else
-    DOWN_REMOVES_VOLUMES=""
-fi
 
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
@@ -68,7 +63,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
+        docker-compose down $SAIL_DOWN_PARAMS
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -355,10 +350,10 @@ if [ $# -gt 0 ]; then
         else
             sail_is_not_running
         fi
-        
-    # Handle the down command...
-    elif [ "$1" == "down" ]; then
-        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
+
+    # Handle the down command if no parameter string is given...
+    elif [ "$1" == "down" ] && [ "$#" == "1" ]; then
+        docker-compose down $SAIL_DOWN_PARAMS
 
     # Pass unknown commands to the "docker-compose" binary...
     else

--- a/bin/sail
+++ b/bin/sail
@@ -63,7 +63,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down $SAIL_DOWN_PARAMS
+        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -351,9 +351,9 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
-    # Handle the down command if no parameter string is given...
+    # Handle the down command when no parameter string is given...
     elif [ "$1" == "down" ] && [ "$#" == "1" ]; then
-        docker-compose down $SAIL_DOWN_PARAMS
+        docker-compose down $DOWN_REMOVES_VOLUMES
 
     # Pass unknown commands to the "docker-compose" binary...
     else

--- a/bin/sail
+++ b/bin/sail
@@ -49,6 +49,12 @@ function sail_is_not_running {
     exit 1
 }
 
+if [ -z "$SAIL_DOWN_REMOVES_VOLUMES" ]; then
+    DOWN_REMOVES_VOLUMES="--volumes"
+else
+    DOWN_REMOVES_VOLUMES=""
+fi
+
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
     if ! docker info > /dev/null 2>&1; then
@@ -62,7 +68,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down > /dev/null 2>&1
+        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -349,6 +355,10 @@ if [ $# -gt 0 ]; then
         else
             sail_is_not_running
         fi
+        
+    # Handle the down command...
+    elif [ "$1" == "down" ]; then
+        docker-compose down $DOWN_REMOVES_VOLUMES > /dev/null 2>&1
 
     # Pass unknown commands to the "docker-compose" binary...
     else


### PR DESCRIPTION
This PR adds the ability to define default `sail down` parameters via a string in the `.env` file.

Example:
```ini
SAIL_DOWN_PARAMS="--volumes --timeout 5"
```

This saves users time when they need to use `down` with non-default options most of the time. If the user runs `down` with their own parameter string, then these defaults will be ignored.
