### PR TITLE
Fix php8.0-dev depending on php8.1-cli

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
     && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu hirsute main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.0-cli php8.0-dev \
+    && apt-get install --no-install-recommends -y php8.0-cli php8.0-dev \
        php8.0-pgsql php8.0-sqlite3 php8.0-gd \
        php8.0-curl php8.0-memcached \
        php8.0-imap php8.0-mysql php8.0-mbstring \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
     && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu hirsute main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install --no-install-recommends -y php8.0-cli php8.0-dev \
+    && apt-get install -y php8.0-cli php8.0-dev \
        php8.0-pgsql php8.0-sqlite3 php8.0-gd \
        php8.0-curl php8.0-memcached \
        php8.0-imap php8.0-mysql php8.0-mbstring \
@@ -42,6 +42,8 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN update-alternatives --set php /usr/bin/php8.0
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 


### PR DESCRIPTION
Fixes https://github.com/laravel/sail/issues/314
As described in https://github.com/laravel/sail/issues/314, the php8.0 runtime installs packages which recommend php-pear which depends on the most recent version of php (8.1).  The results in php8.1 getting installed as the default runtime.  The PR suggest adding –no-install-recommends to the apt-get command in the Dockerfile to prevent the recommendations from being installed.  

I tried this change out and it did prevent php8.1 from being installed.  However, it does mean that php-pear (and any other recommends) are not installed.  As far as I am aware, sail does not depend on php-pear and the container seems to run fine without it (default Laravel page opens in the browser). 

We could also fix this by running an apt-get remove php8.1-cli in the dockerfile after line 31 if we would rather leave recommended packages installed. Thoughts?