### PR TITLE
Allow xdebug auto-connect to listener feature

### DIFF
--- a/runtimes/7.4/php.ini
+++ b/runtimes/7.4/php.ini
@@ -2,3 +2,7 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[XDEBUG]
+
+xdebug.log_level=0

--- a/runtimes/7.4/php.ini
+++ b/runtimes/7.4/php.ini
@@ -4,5 +4,4 @@ upload_max_filesize = 100M
 variables_order = EGPCS
 
 [XDEBUG]
-
 xdebug.log_level=0

--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -2,3 +2,7 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[XDEBUG]
+
+xdebug.log_level=0

--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -4,5 +4,4 @@ upload_max_filesize = 100M
 variables_order = EGPCS
 
 [XDEBUG]
-
 xdebug.log_level=0

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -2,3 +2,7 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[XDEBUG]
+
+xdebug.log_level=0

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -4,5 +4,4 @@ upload_max_filesize = 100M
 variables_order = EGPCS
 
 [XDEBUG]
-
 xdebug.log_level=0

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -17,6 +17,8 @@ services:
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            PHP_IDE_CONFIG: serverName=app
+            XDEBUG_SESSION: app
         volumes:
             - '.:/var/www/html'
         networks:


### PR DESCRIPTION
👋

I always prefer using `Start listening for PHP Debug connections` for debugging - it allows you to debug any CLI (no need to cal sail debug anymore) / browser / external App calling API requests (it can't be done with current setup).

This small improvments enables using the PHPStorm function (and probably other IDEs).

We need to 2 ENV VARIABLES: 

- PHP_IDE_CONFIG - setups which mapping the PHPStorm will use
- XDEBUG_SESSION - starts the xdebug session

xdebug.log_level=0 removes any Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-( messages.

`XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal xdebug.log_level=0}'` in docker-compose.yml did not work.

Of course we can make it optional but by my point of usage there are no performance issues. It just works and its perfect :) (using daily).

This PR requires [Laravel PR](https://github.com/laravel/framework/pull/40673).

## Documentation how to setup

1.  Create run configuration and add PHP Web page. Add server configuration<img width="709" alt="Snímek obrazovky 2022-01-27 v 14 05 50" src="https://user-images.githubusercontent.com/1878831/151366205-1b255b81-343b-482a-8f00-fee542cb4fd1.png">
2. Add server configuration with name `app` - must be same as PHP_IDE_CONFIG. Set `0.0.0.0` to server address, set mapping to `/var/www/html` <img width="834" alt="Snímek obrazovky 2022-01-27 v 14 05 14" src="https://user-images.githubusercontent.com/1878831/151366351-c23af104-55ab-4896-ac92-323b317a48f0.png">

3.  Start debuging :) <img width="195" alt="Snímek obrazovky 2022-01-27 v 13 11 20" src="https://user-images.githubusercontent.com/1878831/151366200-defeafa9-7006-4c7b-b384-43b145f5bc0a.png">

