### PR TITLE
Fix a typo in the "phpunit" command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -160,7 +160,7 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker-compose exec \
-                -u sail
+                -u sail \
                 "$APP_SERVICE" \
                 php vendor/bin/phpunit "$@"
         else


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Just a simple one. It looks like there was a missing `\` in this command that prevented it from executing properly.

Previously, running `sail phpunit` would output an error like this:
```
requires at least 2 arg(s), only received 0
/Users/ike/web/xxxx/vendor/laravel/sail/bin/sail: line 165: laravel.test: command not found
```