### PR TITLE
Typo in replace when checking for ARM for Seleium

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -105,7 +105,7 @@ class InstallCommand extends Command
 
         // Replace Selenium with ARM base container on Apple Silicon...
         if (in_array('selenium', $services) && php_uname('m') === 'arm64') {
-            $stubs = str_replace('selenium/standalone-chrome', 'seleniarm/standalone-chromium', $stubs);
+            $dockerCompose = str_replace('selenium/standalone-chrome', 'seleniarm/standalone-chromium', $dockerCompose);
         }
 
         // Remove empty lines...


### PR DESCRIPTION
Changes made to use `seleniarm/standalone-chromium` when ARM machine is detected would never reach final generated docker-compose.yml.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
