### PR TITLE
Support Newer Docker Compose Exit Statuses

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -59,7 +59,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
 
     # Determine if Sail is currently up...
     PSRESULT="$(docker-compose ps -q)"
-    if docker-compose ps | grep $APP_SERVICE | grep 'Exit'; then
+    if docker-compose ps "$APP_SERVICE" | grep 'Exit\|exited'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
         docker-compose down > /dev/null 2>&1


### PR DESCRIPTION
Older versions of docker-compose use `state=Exit`. Newer versions use `status=exited`. Both support supplying the service directly to the ps command which removes a pipe from the line.

Example old output:
```
     Name                   Command                State     Ports
------------------------------------------------------------------
site_app_1       start-container                  Exit 137
```

Example new output:
```
NAME                                      COMMAND                  SERVICE             STATUS              PORTS
wwwsomewebsitenamedotcom-laravel.test-1   "start-container"        laravel.test        exited (137)
```