### PR TITLE
Add retry fetch to apt get install

### DIFF
--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -13,7 +13,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get  -o Acquire::Retries=3  install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
@@ -21,7 +21,7 @@ RUN apt-get update \
     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C \
     && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu hirsute main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.1-cli php8.1-dev \
+    && apt-get -o Acquire::Retries=3  install -y php8.1-cli php8.1-dev \
        php8.1-pgsql php8.1-sqlite3 php8.1-gd \
        php8.1-curl \
        php8.1-imap php8.1-mysql php8.1-mbstring \
@@ -32,14 +32,14 @@ RUN apt-get update \
        php8.1-memcached php8.1-pcov php8.1-xdebug \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
-    && apt-get install -y nodejs \
+    && apt-get  -o Acquire::Retries=3  install -y nodejs \
     && npm install -g npm \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && apt-get update \
-    && apt-get install -y yarn \
-    && apt-get install -y mysql-client \
-    && apt-get install -y postgresql-client \
+    && apt-get  -o Acquire::Retries=3 install -y yarn \
+    && apt-get  -o Acquire::Retries=3  install -y mysql-client \
+    && apt-get  -o Acquire::Retries=3  install -y postgresql-client \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
I was having a problem building  sail-8.1/app image, it was failing to fetch PHP libs
```sh
#7 133.0 E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/b/binutils/libbinutils_2.36.1-6ubuntu1_amd64.deb  Error reading from server. Remote end closed connection [IP: 91.189.88.142 80]
#7 133.0 E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
------
executor failed running [/bin/sh -c apt-get update     && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2     && mkdir -p ~/.gnupg     && chmod 600 ~/.gnupg     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E5267A6C     && apt-key adv --homedir ~/.gnupg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C300EE8C     && echo "deb http://ppa.launchpad.net/ondrej/php/ubuntu hirsute main" > /etc/apt/sources.list.d/ppa_ondrej_php.list     && apt-get update     && apt-get  install -y php8.1-cli php8.1-dev        php8.1-pgsql php8.1-sqlite3 php8.1-gd        php8.1-curl        php8.1-imap php8.1-mysql php8.1-mbstring        php8.1-xml php8.1-zip php8.1-bcmath php8.1-soap        php8.1-intl php8.1-readline        php8.1-ldap        php8.1-msgpack php8.1-igbinary php8.1-redis php8.1-swoole        php8.1-memcached php8.1-pcov php8.1-xdebug     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer     && curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash -     && apt-get install -y nodejs     && npm install -g npm     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list     && apt-get update     && apt-get install -y yarn     && apt-get install -y mysql-client     && apt-get install -y postgresql-client     && apt-get -y autoremove     && apt-get clean     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*]: exit code: 100
```
Maybe is my isp or my connection, to fix this, I added  -o Acquire::Retries=3  to apt-get install and the problem was fixed. I hope this pull request help someone

Thanks for your time

