### PR TITLE
The input device is not a TTY

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -74,16 +74,20 @@ else
     EXEC="yes"
 fi
 
+NO_TTY=
+if [ ! -t 0 ]; then
+    NO_TTY="true"
+fi
+
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...
     if [ "$1" == "php" ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" "php" "$@")
         else
             sail_is_not_running
         fi
@@ -93,10 +97,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                ./vendor/bin/"$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" ./vendor/bin/"$@")
         else
             sail_is_not_running
         fi
@@ -106,10 +109,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                composer "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" "composer" "$@")
         else
             sail_is_not_running
         fi
@@ -119,10 +121,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" php artisan "$@")
         else
             sail_is_not_running
         fi
@@ -132,11 +133,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e XDEBUG_SESSION=1 \
-                "$APP_SERVICE" \
-                php artisan "$@"
+            ARGS=(exec -u sail -e XDEBUG_SESSION=1)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" php artisan "$@")
         else
             sail_is_not_running
         fi
@@ -146,10 +145,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan test "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" php artisan test "$@")
         else
             sail_is_not_running
         fi
@@ -159,10 +157,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php vendor/bin/phpunit "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" php vendor/bin/phpunit "$@")
         else
             sail_is_not_running
         fi
@@ -172,12 +169,11 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
-                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
-                php artisan dusk "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
+            ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+            ARGS+=("$APP_SERVICE" php artisan dusk "$@")
         else
             sail_is_not_running
         fi
@@ -187,12 +183,11 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                -e "APP_URL=http://${APP_SERVICE}" \
-                -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
-                "$APP_SERVICE" \
-                php artisan dusk:fails "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
+            ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+            ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
         else
             sail_is_not_running
         fi
@@ -202,10 +197,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                php artisan tinker
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" php artisan tinker)
         else
             sail_is_not_running
         fi
@@ -215,10 +209,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                node "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" node "$@")
         else
             sail_is_not_running
         fi
@@ -228,10 +221,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                npm "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" npm "$@")
         else
             sail_is_not_running
         fi
@@ -241,10 +233,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                npx "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" npx "$@")
         else
             sail_is_not_running
         fi
@@ -254,10 +245,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                yarn "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" yarn "$@")
         else
             sail_is_not_running
         fi
@@ -267,9 +257,10 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                mysql \
-                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+            ARGS=(exec)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(mysql bash -c)
+            ARGS+=('MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}')
         else
             sail_is_not_running
         fi
@@ -279,9 +270,10 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                mariadb \
-                bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
+            ARGS=(exec)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(mariadb bash -c)
+            ARGS+=('MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}')
         else
             sail_is_not_running
         fi
@@ -291,9 +283,10 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                 pgsql \
-                 bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
+            ARGS=(exec)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(pgsql bash -c)
+            ARGS+=('PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}')
         else
             sail_is_not_running
         fi
@@ -303,10 +296,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                -u sail \
-                "$APP_SERVICE" \
-                bash "$@"
+            ARGS=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" bash "$@")
         else
             sail_is_not_running
         fi
@@ -316,9 +308,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                "$APP_SERVICE" \
-                bash "$@"
+            ARGS=(exec)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" bash "$@")
         else
             sail_is_not_running
         fi
@@ -328,9 +320,9 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
-                redis \
-                redis-cli
+            ARGS=(exec)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=(redis redis-cli)
         else
             sail_is_not_running
         fi
@@ -341,19 +333,23 @@ if [ $# -gt 0 ]; then
 
         if [ "$EXEC" == "yes" ]; then
             docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
-            --server-host="$SAIL_SHARE_SERVER_HOST" \
-            --server-port="$SAIL_SHARE_SERVER_PORT" \
-            --auth="$SAIL_SHARE_TOKEN" \
-            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
-            "$@"
+                --server-host="$SAIL_SHARE_SERVER_HOST" \
+                --server-port="$SAIL_SHARE_SERVER_PORT" \
+                --auth="$SAIL_SHARE_TOKEN" \
+                --subdomain="$SAIL_SHARE_SUBDOMAIN" \
+                "$@"
+            exit
         else
             sail_is_not_running
         fi
 
     # Pass unknown commands to the "docker-compose" binary...
     else
-        docker-compose "$@"
+        ARGS+=("$@")
     fi
+
+    # Run docker compose with the defined arguments.
+    docker-compose "${ARGS[@]}"
 else
     docker-compose ps
 fi

--- a/bin/sail
+++ b/bin/sail
@@ -74,11 +74,6 @@ else
     EXEC="yes"
 fi
 
-NO_TTY=
-if [ ! -t 0 ]; then
-    NO_TTY="true"
-fi
-
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...
     if [ "$1" == "php" ]; then

--- a/bin/sail-test.sh
+++ b/bin/sail-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+
+# Colors
+blue="\033[1;36m"
+green="\033[1;32m"
+red="\033[1;31m"
+yellow="\033[1;33;40m"
+resetColor="\033[0m"
+
+# Shortcut to run Sail
+ROOT_PATH="$(cd $(dirname $0)/../../../../ && pwd)"
+SAIL_PATH="${ROOT_PATH}/vendor/bin/sail"
+if [ ! -f "${SAIL_PATH}" ]; then
+    echo -e "${red}Sail not found! This test is designed to run under a functioning Laravel application.${resetColor}"
+    exit 1
+fi
+sail() {
+    {
+        set +x
+    } 2>/dev/null
+    "${SAIL_PATH}" "$@"
+}
+
+# Counters
+SUCCESS=0
+FAILURE=0
+
+# Starts sail, this is needed to ensure sail is running and the test validation below will get the error message.
+echo -e "${blue}Starting sail...${resetColor}"
+echo "Under CI environments it is common to have a non TTY console."
+echo "In order to allow Sail to run under those environments, a few tweaks are necessary."
+sail up -d || exit 1
+
+test() {
+    echo -e "${blue}Testing: ${resetColor}${yellow}TTY issue at sail $@${resetColor}"
+    sail "$@" > output 2>&1 &
+
+    wait
+
+    if [ "$(cat output)" == "the input device is not a TTY" ]; then
+        ((FAILURE=FAILURE+1))
+        echo -e "${red}Failed!${resetColor}"
+    else
+        ((SUCCESS=SUCCESS+1))
+        echo -e "${green}Passed!${resetColor}"
+    fi
+
+    # Run `cat output` before this point to debug the test cases.
+    rm -f output
+}
+
+echo -e "${blue}Starting tests...${resetColor}"
+
+test artisan --version
+test bin phpunit --version
+test composer --version
+test node --version
+test npm --version
+test npx --version
+test php --version
+test share --version # This test is expected to pass as the command already ignores TTY.
+test shell -c whoami
+test root-shell -c whoami
+test yarn --version
+
+sail down && {
+    ((SUCCESS=SUCCESS+1))
+    echo -e "${green}Sail stopped.${resetColor}"
+} || {
+    ((FAILURE=FAILURE+1))
+    echo -e "${red}Failed to stop Sail.${resetColor}"
+}
+
+COMPLETE_MSG="${blue}Tests completed!${resetColor} ${green}${SUCCESS} success"
+if [ "${SUCCESS}" != "1" ]; then
+    COMPLETE_MSG="${COMPLETE_MSG}es"
+fi
+COMPLETE_MSG="${COMPLETE_MSG}${resetColor}, ${red}${FAILURE} failure"
+if [ "${FAILURE}" != "1" ]; then
+    COMPLETE_MSG="${COMPLETE_MSG}s"
+fi
+COMPLETE_MSG="${COMPLETE_MSG}${resetColor}"
+
+echo -e "${COMPLETE_MSG}"
+
+# Add error code to the script.
+[ "${FAILURE}" == "0" ]


### PR DESCRIPTION
Running sail commands under some circumstances will yield a "the input device is not a TTY" error, which might happen under CI environments.

This PR is backwards compatible with the current version.

## Testing:
A test shell script was added to validate the issue fix, to run it will require a full installation of Laravel with Sail.

### Seeing the failures
- Drop the `bin/sail-test.sh` in a previous version of Sail
    (or checkout [the commit](https://github.com/laravel/sail/commit/58937dd6f5980390505ff5b5d2154a5a6a914bba) where it was added)
- Run the script and note all except one of the tests fail
