### PR TITLE
Allow overriding docker-compose.yml path using ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+*.iml
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /vendor
 composer.lock
-*.iml
-/.idea/

--- a/bin/sail
+++ b/bin/sail
@@ -35,6 +35,7 @@ export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 
+export SAIL_DOCKER_COMPOSER_YAML=${SAIL_DOCKER_COMPOSER_YAML:-"docker-compose.yml"}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
@@ -58,11 +59,11 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     fi
 
     # Determine if Sail is currently up...
-    PSRESULT="$(docker-compose ps -q)"
-    if docker-compose ps "$APP_SERVICE" | grep 'Exit\|exited'; then
+    PSRESULT="$(docker-compose -f "$SAIL_DOCKER_COMPOSER_YAML" ps -q)"
+    if docker-compose -f "$SAIL_DOCKER_COMPOSER_YAML" ps "$APP_SERVICE" | grep 'Exit\|exited'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose down > /dev/null 2>&1
+        docker-compose -f "$SAIL_DOCKER_COMPOSER_YAML" down > /dev/null 2>&1
 
         EXEC="no"
     elif [ -n "$PSRESULT" ]; then
@@ -80,7 +81,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php "$@"
@@ -93,7 +94,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 ./vendor/bin/"$@"
@@ -106,7 +107,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 composer "$@"
@@ -119,7 +120,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan "$@"
@@ -132,7 +133,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 -e XDEBUG_SESSION=1 \
                 "$APP_SERVICE" \
@@ -146,7 +147,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan test "$@"
@@ -159,7 +160,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php vendor/bin/phpunit "$@"
@@ -172,7 +173,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -187,7 +188,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 -e "APP_URL=http://${APP_SERVICE}" \
                 -e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub" \
@@ -202,7 +203,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 php artisan tinker
@@ -215,7 +216,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 node "$@"
@@ -228,7 +229,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 npm "$@"
@@ -241,7 +242,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 npx "$@"
@@ -254,7 +255,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 yarn "$@"
@@ -267,7 +268,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 mysql \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -279,7 +280,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 mariadb \
                 bash -c 'MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}'
         else
@@ -291,7 +292,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                  pgsql \
                  bash -c 'PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}'
         else
@@ -303,7 +304,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 -u sail \
                 "$APP_SERVICE" \
                 bash "$@"
@@ -316,7 +317,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 "$APP_SERVICE" \
                 bash "$@"
         else
@@ -328,7 +329,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker-compose exec \
+            docker-compose -f $SAIL_DOCKER_COMPOSER_YAML exec \
                 redis \
                 redis-cli
         else
@@ -352,8 +353,8 @@ if [ $# -gt 0 ]; then
 
     # Pass unknown commands to the "docker-compose" binary...
     else
-        docker-compose "$@"
+        docker-compose -f $SAIL_DOCKER_COMPOSER_YAML "$@"
     fi
 else
-    docker-compose ps
+    docker-compose -f $SAIL_DOCKER_COMPOSER_YAML ps
 fi


### PR DESCRIPTION
This PR allows developers to override the `docker-compose.yml` file path; thus supporting different environments e.g. `docker-compose.dev.yml`.

Relates to https://github.com/laravel/sail/issues/348

The file path can be overridden by setting the `SAIL_DOCKER_COMPOSER_YAML` env var in the `.env` file (or at the terminal level).