### PR TITLE
SAIL_FILE environment variable prevents using docker-compose.override.yml

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -35,7 +35,7 @@ export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 
-export SAIL_FILE=${SAIL_FILE:-""}
+export SAIL_FILES=${SAIL_FILES:-""}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
@@ -52,16 +52,20 @@ function sail_is_not_running {
 
 # Define Docker Compose command prefix...
 DOCKER_COMPOSE=(docker-compose)
-if [ -n "$SAIL_FILE" ]; then
-    if [ -f "$SAIL_FILE" ]; then
-        DOCKER_COMPOSE+=(-f "$SAIL_FILE")
-    else
-        echo -e "${WHITE}Can't find file '${SAIL_FILE}'${NC}" >&2
-        echo "" >&2
-        echo -e "${WHITE}Update the 'SAIL_FILE' env variable with a valid path or leave it blank to use the default.${NC}" >&2
+if [ -n "$SAIL_FILES" ]; then
+    # Convert to array...
+    SAIL_FILES=(${SAIL_FILES//:/ })
+    for FILE in "${SAIL_FILES[@]}"; do
+        if [ -f "$FILE" ]; then
+            DOCKER_COMPOSE+=(-f "$FILE")
+        else
+            echo -e "${WHITE}Can't find file '${FILE}'${NC}" >&2
+            echo "" >&2
+            echo -e "${WHITE}Update the 'SAIL_FILES' env variable with valid paths separated by ':' or leave it blank to use the default.${NC}" >&2
 
-        exit 1
-    fi
+            exit 1
+        fi
+    done
 fi
 
 EXEC="yes"

--- a/bin/sail
+++ b/bin/sail
@@ -91,6 +91,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
 fi
 
 ARGS=()
+
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...
     if [ "$1" == "php" ]; then

--- a/bin/sail
+++ b/bin/sail
@@ -52,16 +52,16 @@ function sail_is_not_running {
 
 # Define Docker Compose command prefix...
 DOCKER_COMPOSE=(docker-compose)
+
 if [ -n "$SAIL_FILES" ]; then
-    # Convert to array...
+    # Convert SAIL_FILES to an array...
     SAIL_FILES=(${SAIL_FILES//:/ })
+
     for FILE in "${SAIL_FILES[@]}"; do
         if [ -f "$FILE" ]; then
             DOCKER_COMPOSE+=(-f "$FILE")
         else
-            echo -e "${WHITE}Can't find file '${FILE}'${NC}" >&2
-            echo "" >&2
-            echo -e "${WHITE}Update the 'SAIL_FILES' env variable with valid paths separated by ':' or leave it blank to use the default.${NC}" >&2
+            echo -e "${WHITE}Unable to find Docker Compose file: '${FILE}'${NC}" >&2
 
             exit 1
         fi
@@ -69,6 +69,7 @@ if [ -n "$SAIL_FILES" ]; then
 fi
 
 EXEC="yes"
+
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
     if ! docker info > /dev/null 2>&1; then

--- a/bin/sail
+++ b/bin/sail
@@ -35,7 +35,7 @@ export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 
-export SAIL_FILE=${SAIL_FILE:-"docker-compose.yml"}
+export SAIL_FILE=${SAIL_FILE:-""}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
@@ -50,6 +50,21 @@ function sail_is_not_running {
     exit 1
 }
 
+# Define Docker Compose command prefix...
+DOCKER_COMPOSE=(docker-compose)
+if [ -n "$SAIL_FILE" ]; then
+    if [ -f "$SAIL_FILE" ]; then
+        DOCKER_COMPOSE+=(-f "$SAIL_FILE")
+    else
+        echo -e "${WHITE}Can't find file '${SAIL_FILE}'${NC}" >&2
+        echo "" >&2
+        echo -e "${WHITE}Update the 'SAIL_FILE' env variable with a valid path or leave it blank to use the default.${NC}" >&2
+
+        exit 1
+    fi
+fi
+
+EXEC="yes"
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
     if ! docker info > /dev/null 2>&1; then
@@ -59,24 +74,18 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     fi
 
     # Determine if Sail is currently up...
-    PSRESULT="$(docker-compose -f "$SAIL_FILE" ps -q)"
-    if docker-compose -f "$SAIL_FILE" ps "$APP_SERVICE" | grep 'Exit\|exited'; then
+    if "${DOCKER_COMPOSE[@]}" ps "$APP_SERVICE" | grep 'Exit\|exited'; then
         echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
 
-        docker-compose -f "$SAIL_FILE" down > /dev/null 2>&1
+        "${DOCKER_COMPOSE[@]}" down > /dev/null 2>&1
 
         EXEC="no"
-    elif [ -n "$PSRESULT" ]; then
-        EXEC="yes"
-    else
+    elif [ -z "$(${DOCKER_COMPOSE[@]} ps -q)" ]; then
         EXEC="no"
     fi
-else
-    EXEC="yes"
 fi
 
-ARGS=(-f "$SAIL_FILE")
-
+ARGS=()
 if [ $# -gt 0 ]; then
     # Proxy PHP commands to the "php" binary on the application container...
     if [ "$1" == "php" ]; then
@@ -351,4 +360,4 @@ else
 fi
 
 # Run Docker Compose with the defined arguments...
-docker-compose "${ARGS[@]}"
+"${DOCKER_COMPOSE[@]}" "${ARGS[@]}"


### PR DESCRIPTION
Fixes #354 covering the use-cases presented in the [docs](https://docs.docker.com/compose/extends/#multiple-compose-files)

- Changed the variable name from `SAIL_FILE` to `SAIL_FILES` to better reflect the feature as it is now
- The `SAIL_FILES` variable accepts multiple paths separated by `:`, similar to the `PATH` variable
- Leaving the `SAIL_FILES` variable empty (or undefined) will not add a `-f` to the `docker-compose` command to allow for the default behavior to happen
- Each of the paths is validated if it is a real file before being added to the command:
    - it assumes the path rules from Docker Compose are already taken into account in the configuration
    - it will stop execution early and inform which file didn't pass validation, if any
    - the order of files is preserved as the [docs](https://docs.docker.com/compose/extends/#multiple-compose-files) say it does matter
