### PR TITLE
Added Xdebug auto initialization for xdebug.mode

### DIFF
--- a/runtimes/7.4/php.ini
+++ b/runtimes/7.4/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[Xdebug]
+xdebug.mode=${XDEBUG_MODE}

--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -f .env ]; then
+    SAIL_XDEBUG_MODE=$(grep 'SAIL_XDEBUG_MODE=' .env | sed 's/SAIL_XDEBUG_MODE=//g' | grep . || echo "off")
+    export SAIL_XDEBUG_MODE
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi

--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[Xdebug]
+xdebug.mode=${XDEBUG_MODE}

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -f .env ]; then
+    SAIL_XDEBUG_MODE=$(grep 'SAIL_XDEBUG_MODE=' .env | sed 's/SAIL_XDEBUG_MODE=//g' | grep . || echo "off")
+    export SAIL_XDEBUG_MODE
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[Xdebug]
+xdebug.mode=${XDEBUG_MODE}

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ -f .env ]; then
+    SAIL_XDEBUG_MODE=$(grep 'SAIL_XDEBUG_MODE=' .env | sed 's/SAIL_XDEBUG_MODE=//g' | grep . || echo "off")
+    export SAIL_XDEBUG_MODE
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi


### PR DESCRIPTION
1. Create new env variable `SAIL_XDEBUG_MODE` in the `start-container` which loads the value from the `.env` file
2. Pass `SAIL_XDEBUG_MODE` to `XDEBUG_MODE` in `docker-compose.yml` (already exists)
3. Read env variable in `php.ini`

- Thanks to the entrypoint, it will always be executed at the beginning when starting the container
- PHP needs to be restarted when changing `xdebug.mode`

### How to test:
- Add `SAIL_XDEBUG_MODE=develop,debug` to `.env` [possible values](https://xdebug.org/docs/all_settings#mode)
- Run `sail stop && sail up -d && sail bash`
- Run `php -i | grep xdebug.mode`

# Advantages:
- Runs faster, because it loads the default `off` option :)