### PR TITLE
Shell - display available commands / help section

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -202,6 +202,18 @@ if [ $# -gt 0 ]; then
             sail_is_not_running
         fi
 
+    # Proxy docker-compose commands to the docker-compose binary on the application container...
+    elif [ "$1" == "docker-compose" ]; then
+        shift 1
+
+        if [ "$EXEC" == "yes" ]; then
+            ARGS+=(exec -u sail)
+            [ ! -t 0 ] && ARGS+=(-T)
+            ARGS+=("$APP_SERVICE" "${DOCKER_COMPOSE[@]}")
+        else
+            sail_is_not_running
+        fi
+
     # Proxy Composer commands to the "composer" binary on the application container...
     elif [ "$1" == "composer" ]; then
         shift 1

--- a/bin/sail
+++ b/bin/sail
@@ -174,7 +174,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
     fi
 
     # Determine if Sail is currently up...
-    if "${DOCKER_COMPOSE[@]}" ps "$APP_SERVICE" | grep 'Exit\|exited'; then
+    if "${DOCKER_COMPOSE[@]}" ps "$APP_SERVICE" 2>&1 | grep 'Exit\|exited'; then
         echo "${BOLD}Shutting down old Sail processes...${NC}" >&2
 
         "${DOCKER_COMPOSE[@]}" down > /dev/null 2>&1

--- a/bin/sail
+++ b/bin/sail
@@ -20,10 +20,9 @@ if [ "$MACHINE" == "UNKNOWN" ]; then
     exit 1
 fi
 
-# Check if stdout is a terminal...
+# Determine if stdout is a terminal...
 if test -t 1; then
-
-    # See if it supports colors...
+    # Determine if colors are supported...
     ncolors=$(tput colors)
 
     if test -n "$ncolors" && test "$ncolors" -ge 8; then
@@ -32,7 +31,6 @@ if test -t 1; then
         GREEN="$(tput setaf 2)"
         NC="$(tput sgr0)"
     fi
-
 fi
 
 # Function that prints the available commands...
@@ -42,74 +40,73 @@ function display_help {
     echo "${YELLOW}Usage:${NC}" >&2
     echo "  sail COMMAND [options] [arguments]"
     echo
-    echo "Docker files for running a basic Laravel application."
     echo "Unknown commands are passed to the docker-compose binary."
     echo
-    echo "${YELLOW}Docker-compose Commands:${NC}"
-    echo "  ${GREEN}sail up${NC}        Starts the application"
-    echo "  ${GREEN}sail up -d${NC}     Starts the application in the background"
-    echo "  ${GREEN}sail stop${NC}      Stops the application"
-    echo "  ${GREEN}sail restart${NC}   Restarts the application"
-    echo "  ${GREEN}sail ps${NC}        Displays the status of the containers"
+    echo "${YELLOW}docker-compose Commands:${NC}"
+    echo "  ${GREEN}sail up${NC}        Start the application"
+    echo "  ${GREEN}sail up -d${NC}     Start the application in the background"
+    echo "  ${GREEN}sail stop${NC}      Stop the application"
+    echo "  ${GREEN}sail restart${NC}   Restart the application"
+    echo "  ${GREEN}sail ps${NC}        Display the status of all containers"
     echo
     echo "${YELLOW}Artisan Commands:${NC}"
-    echo "  ${GREEN}sail artisan ...${NC}          Runs an artisan command"
+    echo "  ${GREEN}sail artisan ...${NC}          Run an Artisan command"
     echo "  ${GREEN}sail artisan queue:work${NC}"
     echo
     echo "${YELLOW}PHP Commands:${NC}"
-    echo "  ${GREEN}sail php ...${NC}   Runs a PHP command"
+    echo "  ${GREEN}sail php ...${NC}   Run a snippet of PHP code"
     echo "  ${GREEN}sail php -v${NC}"
     echo
     echo "${YELLOW}Composer Commands:${NC}"
-    echo "  ${GREEN}sail composer ...${NC}                       Runs a composer command"
+    echo "  ${GREEN}sail composer ...${NC}                       Run a Composer command"
     echo "  ${GREEN}sail composer require laravel/sanctum${NC}"
     echo
     echo "${YELLOW}Node Commands:${NC}"
-    echo "  ${GREEN}sail node ...${NC}         Runs a node command"
+    echo "  ${GREEN}sail node ...${NC}         Run a Node command"
     echo "  ${GREEN}sail node --version${NC}"
     echo
     echo "${YELLOW}NPM Commands:${NC}"
-    echo "  ${GREEN}sail npm ...${NC}        Runs a npm command"
-    echo "  ${GREEN}sail npx${NC}            Runs a npx command"
+    echo "  ${GREEN}sail npm ...${NC}        Run a npm command"
+    echo "  ${GREEN}sail npx${NC}            Run a npx command"
     echo "  ${GREEN}sail npm run prod${NC}"
     echo
     echo "${YELLOW}Yarn Commands:${NC}"
-    echo "  ${GREEN}sail yarn ...${NC}        Runs a yarn command"
+    echo "  ${GREEN}sail yarn ...${NC}        Run a Yarn command"
     echo "  ${GREEN}sail yarn run prod${NC}"
     echo
     echo "${YELLOW}Database Commands:${NC}"
-    echo "  ${GREEN}sail mysql${NC}     Instantiate a MySQL CLI session within the 'mysql' container"
-    echo "  ${GREEN}sail mariadb${NC}   Instantiate a MySQL CLI session within the 'mariadb' container"
-    echo "  ${GREEN}sail psql${NC}      Instantiate a PostgreSQL CLI session within the 'pgsql' container"
-    echo "  ${GREEN}sail redis${NC}     Instantiate a Redis CLI session within the 'redis' container"
+    echo "  ${GREEN}sail mysql${NC}     Start a MySQL CLI session within the 'mysql' container"
+    echo "  ${GREEN}sail mariadb${NC}   Start a MySQL CLI session within the 'mariadb' container"
+    echo "  ${GREEN}sail psql${NC}      Start a PostgreSQL CLI session within the 'pgsql' container"
+    echo "  ${GREEN}sail redis${NC}     Start a Redis CLI session within the 'redis' container"
     echo
     echo "${YELLOW}Debugging:${NC}"
-    echo "  ${GREEN}sail debug ...${NC}          Runs an artisan command in debug mode"
+    echo "  ${GREEN}sail debug ...${NC}          Run an Artisan command in debug mode"
     echo "  ${GREEN}sail debug queue:work${NC}"
     echo
     echo "${YELLOW}Running Tests:${NC}"
-    echo "  ${GREEN}sail test${NC}          Runs the PHPUnit tests"
-    echo "  ${GREEN}sail phpunit ...${NC}   Runs the vNCor/bin/phpunit binary"
-    echo "  ${GREEN}sail dusk${NC}          Runs the Dusk tests (Requires the laravel/dusk package)"
+    echo "  ${GREEN}sail test${NC}          Run the PHPUnit tests via the Artisan test command"
+    echo "  ${GREEN}sail phpunit ...${NC}   Run PHPUnit"
+    echo "  ${GREEN}sail dusk${NC}          Run the Dusk tests (Requires the laravel/dusk package)"
     echo
     echo "${YELLOW}Container CLI:${NC}"
-    echo "  ${GREEN}sail shell${NC}        Connect to the container's shell"
+    echo "  ${GREEN}sail shell${NC}        Start a shell session within the application container"
     echo "  ${GREEN}sail bash${NC}         Alias for 'sail shell'"
-    echo "  ${GREEN}sail root-shell${NC}   Connect to the container's root shell"
+    echo "  ${GREEN}sail root-shell${NC}   Start a root shell session within the application container"
     echo "  ${GREEN}sail root-bash${NC}    Alias for 'sail root-shell'"
-    echo "  ${GREEN}sail tinker${NC}       Starts a new Laravel Tinker session"
+    echo "  ${GREEN}sail tinker${NC}       Start a new Laravel Tinker session"
     echo
-    echo "${YELLOW}Share Site:${NC}"
-    echo "  ${GREEN}sail share${NC}   Makes the application available on the internet"
+    echo "${YELLOW}Sharing:${NC}"
+    echo "  ${GREEN}sail share${NC}   Share the application publicly via a temporary URL"
     echo
     echo "${YELLOW}Customization:${NC}"
-    echo "  ${GREEN}sail artisan sail:publish${NC}   Publishes the Sail configuration files"
-    echo "  ${GREEN}sail build --no-cache${NC}       Rebuilds the containers"
+    echo "  ${GREEN}sail artisan sail:publish${NC}   Publish the Sail configuration files"
+    echo "  ${GREEN}sail build --no-cache${NC}       Rebuild all of the Sail containers"
 
     exit 1
 }
 
-# Proxy the "help" command to show a list of available commands...
+# Proxy the "help" command...
 if [ $# -gt 0 ]; then
     if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
         display_help

--- a/bin/sail
+++ b/bin/sail
@@ -7,8 +7,20 @@ fi
 
 UNAMEOUT="$(uname -s)"
 
-WHITE='\033[1;37m'
-NC='\033[0m'
+# Check if stdout is a terminal...
+if test -t 1; then
+
+    # See if it supports colors...
+    ncolors=$(tput colors)
+
+    if test -n "$ncolors" && test "$ncolors" -ge 8; then
+        BOLD="$(tput bold)"
+        YELLOW="$(tput setaf 3)"
+        GREEN="$(tput setaf 2)"
+        NC="$(tput sgr0)"
+    fi
+
+fi
 
 # Verify operating system is supported...
 case "${UNAMEOUT}" in
@@ -43,87 +55,83 @@ export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
-    echo -e "${WHITE}Sail is not running.${NC}" >&2
+    echo "${BOLD}Sail is not running.${NC}" >&2
     echo "" >&2
-    echo -e "${WHITE}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+    echo "${BOLD}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
 
     exit 1
 }
 
 # Function that prints the available commands...
 function display_help {
-    YELLOW='\e[33m'
-    GREEN='\e[32m'
-    END='\e[0m'
-
-    echo -e "Laravel Sail"
+    echo "Laravel Sail"
     echo
-    echo -e "${YELLOW}Usage:${END}" >&2
-    echo -e "  sail COMMAND [options] [arguments]"
+    echo "${YELLOW}Usage:${NC}" >&2
+    echo "  sail COMMAND [options] [arguments]"
     echo
-    echo -e "Docker files for running a basic Laravel application."
-    echo -e "Unknown commands are passed to the docker-compose binary."
+    echo "Docker files for running a basic Laravel application."
+    echo "Unknown commands are passed to the docker-compose binary."
     echo
-    echo -e "${YELLOW}Docker-compose Commands:${END}"
-    echo -e "  ${GREEN}sail up${END}        Starts the application"
-    echo -e "  ${GREEN}sail up -d${END}     Starts the application in the background"
-    echo -e "  ${GREEN}sail stop${END}      Stops the application"
-    echo -e "  ${GREEN}sail restart${END}   Restarts the application"
-    echo -e "  ${GREEN}sail ps${END}        Displays the status of the containers"
+    echo "${YELLOW}Docker-compose Commands:${NC}"
+    echo "  ${GREEN}sail up${NC}        Starts the application"
+    echo "  ${GREEN}sail up -d${NC}     Starts the application in the background"
+    echo "  ${GREEN}sail stop${NC}      Stops the application"
+    echo "  ${GREEN}sail restart${NC}   Restarts the application"
+    echo "  ${GREEN}sail ps${NC}        Displays the status of the containers"
     echo
-    echo -e "${YELLOW}Artisan Commands:${END}"
-    echo -e "  ${GREEN}sail artisan ...${END}          Runs an artisan command"
-    echo -e "  ${GREEN}sail artisan queue:work${END}"
+    echo "${YELLOW}Artisan Commands:${NC}"
+    echo "  ${GREEN}sail artisan ...${NC}          Runs an artisan command"
+    echo "  ${GREEN}sail artisan queue:work${NC}"
     echo
-    echo -e "${YELLOW}PHP Commands:${END}"
-    echo -e "  ${GREEN}sail php ...${END}   Runs a PHP command"
-    echo -e "  ${GREEN}sail php -v${END}"
+    echo "${YELLOW}PHP Commands:${NC}"
+    echo "  ${GREEN}sail php ...${NC}   Runs a PHP command"
+    echo "  ${GREEN}sail php -v${NC}"
     echo
-    echo -e "${YELLOW}Composer Commands:${END}"
-    echo -e "  ${GREEN}sail composer ...${END}                       Runs a composer command"
-    echo -e "  ${GREEN}sail composer require laravel/sanctum${END}"
+    echo "${YELLOW}Composer Commands:${NC}"
+    echo "  ${GREEN}sail composer ...${NC}                       Runs a composer command"
+    echo "  ${GREEN}sail composer require laravel/sanctum${NC}"
     echo
-    echo -e "${YELLOW}Node Commands:${END}"
-    echo -e "  ${GREEN}sail node ...${END}         Runs a node command"
-    echo -e "  ${GREEN}sail node --version${END}"
+    echo "${YELLOW}Node Commands:${NC}"
+    echo "  ${GREEN}sail node ...${NC}         Runs a node command"
+    echo "  ${GREEN}sail node --version${NC}"
     echo
-    echo -e "${YELLOW}NPM Commands:${END}"
-    echo -e "  ${GREEN}sail npm ...${END}        Runs a npm command"
-    echo -e "  ${GREEN}sail npx${END}            Runs a npx command"
-    echo -e "  ${GREEN}sail npm run prod${END}"
+    echo "${YELLOW}NPM Commands:${NC}"
+    echo "  ${GREEN}sail npm ...${NC}        Runs a npm command"
+    echo "  ${GREEN}sail npx${NC}            Runs a npx command"
+    echo "  ${GREEN}sail npm run prod${NC}"
     echo
-    echo -e "${YELLOW}Yarn Commands:${END}"
-    echo -e "  ${GREEN}sail yarn ...${END}        Runs a yarn command"
-    echo -e "  ${GREEN}sail yarn run prod${END}"
+    echo "${YELLOW}Yarn Commands:${NC}"
+    echo "  ${GREEN}sail yarn ...${NC}        Runs a yarn command"
+    echo "  ${GREEN}sail yarn run prod${NC}"
     echo
-    echo -e "${YELLOW}Database Commands:${END}"
-    echo -e "  ${GREEN}sail mysql${END}     Instantiate a MySQL CLI session within the 'mysql' container"
-    echo -e "  ${GREEN}sail mariadb${END}   Instantiate a MySQL CLI session within the 'mariadb' container"
-    echo -e "  ${GREEN}sail psql${END}      Instantiate a PostgreSQL CLI session within the 'pgsql' container"
-    echo -e "  ${GREEN}sail redis${END}     Instantiate a Redis CLI session within the 'redis' container"
+    echo "${YELLOW}Database Commands:${NC}"
+    echo "  ${GREEN}sail mysql${NC}     Instantiate a MySQL CLI session within the 'mysql' container"
+    echo "  ${GREEN}sail mariadb${NC}   Instantiate a MySQL CLI session within the 'mariadb' container"
+    echo "  ${GREEN}sail psql${NC}      Instantiate a PostgreSQL CLI session within the 'pgsql' container"
+    echo "  ${GREEN}sail redis${NC}     Instantiate a Redis CLI session within the 'redis' container"
     echo
-    echo -e "${YELLOW}Debugging:${END}"
-    echo -e "  ${GREEN}sail debug ...${END}          Runs an artisan command in debug mode"
-    echo -e "  ${GREEN}sail debug queue:work${END}"
+    echo "${YELLOW}Debugging:${NC}"
+    echo "  ${GREEN}sail debug ...${NC}          Runs an artisan command in debug mode"
+    echo "  ${GREEN}sail debug queue:work${NC}"
     echo
-    echo -e "${YELLOW}Running Tests:${END}"
-    echo -e "  ${GREEN}sail test${END}          Runs the PHPUnit tests"
-    echo -e "  ${GREEN}sail phpunit ...${END}   Runs the vendor/bin/phpunit binary"
-    echo -e "  ${GREEN}sail dusk${END}          Runs the Dusk tests (Requires the laravel/dusk package)"
+    echo "${YELLOW}Running Tests:${NC}"
+    echo "  ${GREEN}sail test${NC}          Runs the PHPUnit tests"
+    echo "  ${GREEN}sail phpunit ...${NC}   Runs the vNCor/bin/phpunit binary"
+    echo "  ${GREEN}sail dusk${NC}          Runs the Dusk tests (Requires the laravel/dusk package)"
     echo
-    echo -e "${YELLOW}Container CLI:${END}"
-    echo -e "  ${GREEN}sail shell${END}        Connect to the container's shell"
-    echo -e "  ${GREEN}sail bash${END}         Alias for 'sail shell'"
-    echo -e "  ${GREEN}sail root-shell${END}   Connect to the container's root shell"
-    echo -e "  ${GREEN}sail root-bash${END}    Alias for 'sail root-shell'"
-    echo -e "  ${GREEN}sail tinker${END}       Starts a new Laravel Tinker session"
+    echo "${YELLOW}Container CLI:${NC}"
+    echo "  ${GREEN}sail shell${NC}        Connect to the container's shell"
+    echo "  ${GREEN}sail bash${NC}         Alias for 'sail shell'"
+    echo "  ${GREEN}sail root-shell${NC}   Connect to the container's root shell"
+    echo "  ${GREEN}sail root-bash${NC}    Alias for 'sail root-shell'"
+    echo "  ${GREEN}sail tinker${NC}       Starts a new Laravel Tinker session"
     echo
-    echo -e "${YELLOW}Share Site:${END}"
-    echo -e "  ${GREEN}sail share${END}   Makes the application available on the internet"
+    echo "${YELLOW}Share Site:${NC}"
+    echo "  ${GREEN}sail share${NC}   Makes the application available on the internet"
     echo
-    echo -e "${YELLOW}Customization:${END}"
-    echo -e "  ${GREEN}sail artisan sail:publish${END}   Publishes the Sail configuration files"
-    echo -e "  ${GREEN}sail build --no-cache${END}       Rebuilds the containers"
+    echo "${YELLOW}Customization:${NC}"
+    echo "  ${GREEN}sail artisan sail:publish${NC}   Publishes the Sail configuration files"
+    echo "  ${GREEN}sail build --no-cache${NC}       Rebuilds the containers"
 
     exit 1
 }
@@ -139,7 +147,7 @@ if [ -n "$SAIL_FILES" ]; then
         if [ -f "$FILE" ]; then
             DOCKER_COMPOSE+=(-f "$FILE")
         else
-            echo -e "${WHITE}Unable to find Docker Compose file: '${FILE}'${NC}" >&2
+            echo "${BOLD}Unable to find Docker Compose file: '${FILE}'${NC}" >&2
 
             exit 1
         fi
@@ -151,14 +159,14 @@ EXEC="yes"
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
     if ! docker info > /dev/null 2>&1; then
-        echo -e "${WHITE}Docker is not running.${NC}" >&2
+        echo "${BOLD}Docker is not running.${NC}" >&2
 
         exit 1
     fi
 
     # Determine if Sail is currently up...
     if "${DOCKER_COMPOSE[@]}" ps "$APP_SERVICE" | grep 'Exit\|exited'; then
-        echo -e "${WHITE}Shutting down old Sail processes...${NC}" >&2
+        echo "${BOLD}Shutting down old Sail processes...${NC}" >&2
 
         "${DOCKER_COMPOSE[@]}" down > /dev/null 2>&1
 

--- a/bin/sail
+++ b/bin/sail
@@ -133,7 +133,7 @@ DOCKER_COMPOSE=(docker-compose)
 
 if [ -n "$SAIL_FILES" ]; then
     # Convert SAIL_FILES to an array...
-    SAIL_FILES=(${SAIL_FILES//:/ })
+    SAIL_FILES=("${SAIL_FILES//:/ }")
 
     for FILE in "${SAIL_FILES[@]}"; do
         if [ -f "$FILE" ]; then
@@ -163,7 +163,7 @@ if [ -z "$SAIL_SKIP_CHECKS" ]; then
         "${DOCKER_COMPOSE[@]}" down > /dev/null 2>&1
 
         EXEC="no"
-    elif [ -z "$(${DOCKER_COMPOSE[@]} ps -q)" ]; then
+    elif [ -z "$("${DOCKER_COMPOSE[@]}" ps -q)" ]; then
         EXEC="no"
     fi
 fi
@@ -358,7 +358,7 @@ if [ $# -gt 0 ]; then
             ARGS+=(exec)
             [ ! -t 0 ] && ARGS+=(-T)
             ARGS+=(mysql bash -c)
-            ARGS+=('MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}')
+            ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
         else
             sail_is_not_running
         fi
@@ -371,7 +371,7 @@ if [ $# -gt 0 ]; then
             ARGS+=(exec)
             [ ! -t 0 ] && ARGS+=(-T)
             ARGS+=(mariadb bash -c)
-            ARGS+=('MYSQL_PWD=${MYSQL_PASSWORD} mysql -u ${MYSQL_USER} ${MYSQL_DATABASE}')
+            ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
         else
             sail_is_not_running
         fi
@@ -384,7 +384,7 @@ if [ $# -gt 0 ]; then
             ARGS+=(exec)
             [ ! -t 0 ] && ARGS+=(-T)
             ARGS+=(pgsql bash -c)
-            ARGS+=('PGPASSWORD=${PGPASSWORD} psql -U ${POSTGRES_USER} ${POSTGRES_DB}')
+            ARGS+=("PGPASSWORD=\${PGPASSWORD} psql -U \${POSTGRES_USER} \${POSTGRES_DB}")
         else
             sail_is_not_running
         fi
@@ -430,7 +430,7 @@ if [ $# -gt 0 ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
-            docker run --init --rm -p $SAIL_SHARE_DASHBOARD:4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            docker run --init --rm -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
                 --server-host="$SAIL_SHARE_SERVER_HOST" \
                 --server-port="$SAIL_SHARE_SERVER_PORT" \
                 --auth="$SAIL_SHARE_TOKEN" \

--- a/bin/sail
+++ b/bin/sail
@@ -50,6 +50,84 @@ function sail_is_not_running {
     exit 1
 }
 
+# Function that prints the available commands...
+function display_help {
+    YELLOW='\e[33m'
+    GREEN='\e[32m'
+    END='\e[0m'
+
+    echo -e "Laravel Sail"
+    echo
+    echo -e "${YELLOW}Usage:${END}" >&2
+    echo -e "  sail COMMAND [options] [arguments]"
+    echo
+    echo -e "Docker files for running a basic Laravel application."
+    echo -e "Unknown commands are passed to the docker-compose binary."
+    echo
+    echo -e "${YELLOW}Docker-compose Commands:${END}"
+    echo -e "  ${GREEN}sail up${END}        Starts the application"
+    echo -e "  ${GREEN}sail up -d${END}     Starts the application in the background"
+    echo -e "  ${GREEN}sail stop${END}      Stops the application"
+    echo -e "  ${GREEN}sail restart${END}   Restarts the application"
+    echo -e "  ${GREEN}sail ps${END}        Displays the status of the containers"
+    echo
+    echo -e "${YELLOW}Artisan Commands:${END}"
+    echo -e "  ${GREEN}sail artisan ...${END}          Runs an artisan command"
+    echo -e "  ${GREEN}sail artisan queue:work${END}"
+    echo
+    echo -e "${YELLOW}PHP Commands:${END}"
+    echo -e "  ${GREEN}sail php ...${END}   Runs a PHP command"
+    echo -e "  ${GREEN}sail php -v${END}"
+    echo
+    echo -e "${YELLOW}Composer Commands:${END}"
+    echo -e "  ${GREEN}sail composer ...${END}                       Runs a composer command"
+    echo -e "  ${GREEN}sail composer require laravel/sanctum${END}"
+    echo
+    echo -e "${YELLOW}Node Commands:${END}"
+    echo -e "  ${GREEN}sail node ...${END}         Runs a node command"
+    echo -e "  ${GREEN}sail node --version${END}"
+    echo
+    echo -e "${YELLOW}NPM Commands:${END}"
+    echo -e "  ${GREEN}sail npm ...${END}        Runs a npm command"
+    echo -e "  ${GREEN}sail npx${END}            Runs a npx command"
+    echo -e "  ${GREEN}sail npm run prod${END}"
+    echo
+    echo -e "${YELLOW}Yarn Commands:${END}"
+    echo -e "  ${GREEN}sail yarn ...${END}        Runs a yarn command"
+    echo -e "  ${GREEN}sail yarn run prod${END}"
+    echo
+    echo -e "${YELLOW}Database Commands:${END}"
+    echo -e "  ${GREEN}sail mysql${END}     Instantiate a MySQL CLI session within the 'mysql' container"
+    echo -e "  ${GREEN}sail mariadb${END}   Instantiate a MySQL CLI session within the 'mariadb' container"
+    echo -e "  ${GREEN}sail psql${END}      Instantiate a PostgreSQL CLI session within the 'pgsql' container"
+    echo -e "  ${GREEN}sail redis${END}     Instantiate a Redis CLI session within the 'redis' container"
+    echo
+    echo -e "${YELLOW}Debugging:${END}"
+    echo -e "  ${GREEN}sail debug ...${END}          Runs an artisan command in debug mode"
+    echo -e "  ${GREEN}sail debug queue:work${END}"
+    echo
+    echo -e "${YELLOW}Running Tests:${END}"
+    echo -e "  ${GREEN}sail test${END}          Runs the PHPUnit tests"
+    echo -e "  ${GREEN}sail phpunit ...${END}   Runs the vendor/bin/phpunit binary"
+    echo -e "  ${GREEN}sail dusk${END}          Runs the Dusk tests (Requires the laravel/dusk package)"
+    echo
+    echo -e "${YELLOW}Container CLI:${END}"
+    echo -e "  ${GREEN}sail shell${END}        Connect to the container's shell"
+    echo -e "  ${GREEN}sail bash${END}         Alias for 'sail shell'"
+    echo -e "  ${GREEN}sail root-shell${END}   Connect to the container's root shell"
+    echo -e "  ${GREEN}sail root-bash${END}    Alias for 'sail root-shell'"
+    echo -e "  ${GREEN}sail tinker${END}       Starts a new Laravel Tinker session"
+    echo
+    echo -e "${YELLOW}Share Site:${END}"
+    echo -e "  ${GREEN}sail share${END}   Makes the application available on the internet"
+    echo
+    echo -e "${YELLOW}Customization:${END}"
+    echo -e "  ${GREEN}sail artisan sail:publish${END}   Publishes the Sail configuration files"
+    echo -e "  ${GREEN}sail build --no-cache${END}       Rebuilds the containers"
+
+    exit 1
+}
+
 # Define Docker Compose command prefix...
 DOCKER_COMPOSE=(docker-compose)
 
@@ -93,8 +171,15 @@ fi
 ARGS=()
 
 if [ $# -gt 0 ]; then
+
+    # Proxy the "help" command to show a list of available commands...
+    if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
+        shift 1
+
+        display_help
+
     # Proxy PHP commands to the "php" binary on the application container...
-    if [ "$1" == "php" ]; then
+    elif [ "$1" == "php" ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
@@ -317,7 +402,7 @@ if [ $# -gt 0 ]; then
         fi
 
     # Initiate a root user Bash shell within the application container...
-    elif [ "$1" == "root-shell" ] ; then
+    elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
         shift 1
 
         if [ "$EXEC" == "yes" ]; then
@@ -362,7 +447,7 @@ if [ $# -gt 0 ]; then
         ARGS+=("$@")
     fi
 else
-    ARGS+=(ps)
+    display_help
 fi
 
 # Run Docker Compose with the defined arguments...

--- a/bin/sail
+++ b/bin/sail
@@ -7,6 +7,19 @@ fi
 
 UNAMEOUT="$(uname -s)"
 
+# Verify operating system is supported...
+case "${UNAMEOUT}" in
+    Linux*)             MACHINE=linux;;
+    Darwin*)            MACHINE=mac;;
+    *)                  MACHINE="UNKNOWN"
+esac
+
+if [ "$MACHINE" == "UNKNOWN" ]; then
+    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
+
+    exit 1
+fi
+
 # Check if stdout is a terminal...
 if test -t 1; then
 
@@ -21,46 +34,6 @@ if test -t 1; then
     fi
 
 fi
-
-# Verify operating system is supported...
-case "${UNAMEOUT}" in
-    Linux*)             MACHINE=linux;;
-    Darwin*)            MACHINE=mac;;
-    *)                  MACHINE="UNKNOWN"
-esac
-
-if [ "$MACHINE" == "UNKNOWN" ]; then
-    echo "Unsupported operating system [$(uname -s)]. Laravel Sail supports macOS, Linux, and Windows (WSL2)." >&2
-
-    exit 1
-fi
-
-# Source the ".env" file so Laravel's environment variables are available...
-if [ -f ./.env ]; then
-    source ./.env
-fi
-
-# Define environment variables...
-export APP_PORT=${APP_PORT:-80}
-export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
-export DB_PORT=${DB_PORT:-3306}
-export WWWUSER=${WWWUSER:-$UID}
-export WWWGROUP=${WWWGROUP:-$(id -g)}
-
-export SAIL_FILES=${SAIL_FILES:-""}
-export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
-export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
-export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
-export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
-
-# Function that outputs Sail is not running...
-function sail_is_not_running {
-    echo "${BOLD}Sail is not running.${NC}" >&2
-    echo "" >&2
-    echo "${BOLD}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
-
-    exit 1
-}
 
 # Function that prints the available commands...
 function display_help {
@@ -136,6 +109,42 @@ function display_help {
     exit 1
 }
 
+# Proxy the "help" command to show a list of available commands...
+if [ $# -gt 0 ]; then
+    if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
+        display_help
+    fi
+else
+    display_help
+fi
+
+# Source the ".env" file so Laravel's environment variables are available...
+if [ -f ./.env ]; then
+    source ./.env
+fi
+
+# Define environment variables...
+export APP_PORT=${APP_PORT:-80}
+export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export DB_PORT=${DB_PORT:-3306}
+export WWWUSER=${WWWUSER:-$UID}
+export WWWGROUP=${WWWGROUP:-$(id -g)}
+
+export SAIL_FILES=${SAIL_FILES:-""}
+export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
+export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
+export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
+export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
+
+# Function that outputs Sail is not running...
+function sail_is_not_running {
+    echo "${BOLD}Sail is not running.${NC}" >&2
+    echo "" >&2
+    echo "${BOLD}You may Sail using the following commands:${NC} './vendor/bin/sail up' or './vendor/bin/sail up -d'" >&2
+
+    exit 1
+}
+
 # Define Docker Compose command prefix...
 DOCKER_COMPOSE=(docker-compose)
 
@@ -178,296 +187,285 @@ fi
 
 ARGS=()
 
-if [ $# -gt 0 ]; then
+# Proxy PHP commands to the "php" binary on the application container...
+if [ "$1" == "php" ]; then
+    shift 1
 
-    # Proxy the "help" command to show a list of available commands...
-    if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
-        shift 1
-
-        display_help
-
-    # Proxy PHP commands to the "php" binary on the application container...
-    elif [ "$1" == "php" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" "php" "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy vendor binary commands on the application container...
-    elif [ "$1" == "bin" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" ./vendor/bin/"$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy docker-compose commands to the docker-compose binary on the application container...
-    elif [ "$1" == "docker-compose" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" "${DOCKER_COMPOSE[@]}")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy Composer commands to the "composer" binary on the application container...
-    elif [ "$1" == "composer" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" "composer" "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy Artisan commands to the "artisan" binary on the application container...
-    elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" php artisan "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "debug" command to the "php artisan" binary on the application container with xdebug enabled...
-    elif [ "$1" == "debug" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail -e XDEBUG_SESSION=1)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" php artisan "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "test" command to the "php artisan test" Artisan command...
-    elif [ "$1" == "test" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" php artisan test "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "phpunit" command to "php vendor/bin/phpunit"...
-    elif [ "$1" == "phpunit" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" php vendor/bin/phpunit "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "dusk" command to the "php artisan dusk" Artisan command...
-    elif [ "$1" == "dusk" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
-            ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
-            ARGS+=("$APP_SERVICE" php artisan dusk "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy the "dusk:fails" command to the "php artisan dusk:fails" Artisan command...
-    elif [ "$1" == "dusk:fails" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
-            ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
-            ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a Laravel Tinker session within the application container...
-    elif [ "$1" == "tinker" ] ; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" php artisan tinker)
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy Node commands to the "node" binary on the application container...
-    elif [ "$1" == "node" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" node "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy NPM commands to the "npm" binary on the application container...
-    elif [ "$1" == "npm" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" npm "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy NPX commands to the "npx" binary on the application container...
-    elif [ "$1" == "npx" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" npx "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Proxy YARN commands to the "yarn" binary on the application container...
-    elif [ "$1" == "yarn" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" yarn "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a MySQL CLI terminal session within the "mysql" container...
-    elif [ "$1" == "mysql" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(mysql bash -c)
-            ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a MySQL CLI terminal session within the "mariadb" container...
-    elif [ "$1" == "mariadb" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(mariadb bash -c)
-            ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a PostgreSQL CLI terminal session within the "pgsql" container...
-    elif [ "$1" == "psql" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(pgsql bash -c)
-            ARGS+=("PGPASSWORD=\${PGPASSWORD} psql -U \${POSTGRES_USER} \${POSTGRES_DB}")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a Bash shell within the application container...
-    elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec -u sail)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" bash "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a root user Bash shell within the application container...
-    elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=("$APP_SERVICE" bash "$@")
-        else
-            sail_is_not_running
-        fi
-
-    # Initiate a Redis CLI terminal session within the "redis" container...
-    elif [ "$1" == "redis" ] ; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            ARGS+=(exec)
-            [ ! -t 0 ] && ARGS+=(-T)
-            ARGS+=(redis redis-cli)
-        else
-            sail_is_not_running
-        fi
-
-    # Share the site...
-    elif [ "$1" == "share" ]; then
-        shift 1
-
-        if [ "$EXEC" == "yes" ]; then
-            docker run --init --rm -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
-                --server-host="$SAIL_SHARE_SERVER_HOST" \
-                --server-port="$SAIL_SHARE_SERVER_PORT" \
-                --auth="$SAIL_SHARE_TOKEN" \
-                --subdomain="$SAIL_SHARE_SUBDOMAIN" \
-                "$@"
-
-            exit
-        else
-            sail_is_not_running
-        fi
-
-    # Pass unknown commands to the "docker-compose" binary...
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "php" "$@")
     else
-        ARGS+=("$@")
+        sail_is_not_running
     fi
+
+# Proxy vendor binary commands on the application container...
+elif [ "$1" == "bin" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" ./vendor/bin/"$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy docker-compose commands to the docker-compose binary on the application container...
+elif [ "$1" == "docker-compose" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "${DOCKER_COMPOSE[@]}")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy Composer commands to the "composer" binary on the application container...
+elif [ "$1" == "composer" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "composer" "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy Artisan commands to the "artisan" binary on the application container...
+elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" php artisan "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy the "debug" command to the "php artisan" binary on the application container with xdebug enabled...
+elif [ "$1" == "debug" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail -e XDEBUG_SESSION=1)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" php artisan "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy the "test" command to the "php artisan test" Artisan command...
+elif [ "$1" == "test" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" php artisan test "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy the "phpunit" command to "php vendor/bin/phpunit"...
+elif [ "$1" == "phpunit" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" php vendor/bin/phpunit "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy the "dusk" command to the "php artisan dusk" Artisan command...
+elif [ "$1" == "dusk" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
+        ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+        ARGS+=("$APP_SERVICE" php artisan dusk "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy the "dusk:fails" command to the "php artisan dusk:fails" Artisan command...
+elif [ "$1" == "dusk:fails" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
+        ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+        ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a Laravel Tinker session within the application container...
+elif [ "$1" == "tinker" ] ; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" php artisan tinker)
+    else
+        sail_is_not_running
+    fi
+
+# Proxy Node commands to the "node" binary on the application container...
+elif [ "$1" == "node" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" node "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy NPM commands to the "npm" binary on the application container...
+elif [ "$1" == "npm" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" npm "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy NPX commands to the "npx" binary on the application container...
+elif [ "$1" == "npx" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" npx "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy YARN commands to the "yarn" binary on the application container...
+elif [ "$1" == "yarn" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" yarn "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a MySQL CLI terminal session within the "mysql" container...
+elif [ "$1" == "mysql" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(mysql bash -c)
+        ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a MySQL CLI terminal session within the "mariadb" container...
+elif [ "$1" == "mariadb" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(mariadb bash -c)
+        ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a PostgreSQL CLI terminal session within the "pgsql" container...
+elif [ "$1" == "psql" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(pgsql bash -c)
+        ARGS+=("PGPASSWORD=\${PGPASSWORD} psql -U \${POSTGRES_USER} \${POSTGRES_DB}")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a Bash shell within the application container...
+elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" bash "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a root user Bash shell within the application container...
+elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" bash "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a Redis CLI terminal session within the "redis" container...
+elif [ "$1" == "redis" ] ; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(redis redis-cli)
+    else
+        sail_is_not_running
+    fi
+
+# Share the site...
+elif [ "$1" == "share" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        docker run --init --rm -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+            --server-host="$SAIL_SHARE_SERVER_HOST" \
+            --server-port="$SAIL_SHARE_SERVER_PORT" \
+            --auth="$SAIL_SHARE_TOKEN" \
+            --subdomain="$SAIL_SHARE_SUBDOMAIN" \
+            "$@"
+
+        exit
+    else
+        sail_is_not_running
+    fi
+
+# Pass unknown commands to the "docker-compose" binary...
 else
-    display_help
+    ARGS+=("$@")
 fi
 
 # Run Docker Compose with the defined arguments...


### PR DESCRIPTION
## Changes:
- `vendor/bin/sail` now executes the help section, instead of the `docker ps` command
- New command aliases for the help section: `sail help`, `sail -help`, `sail --help` and `sail -h`
- New command alias for docker-compose: `sail docker-compose`
  - (Unknown commands still proxy to docker-compose)
- New command alias for `root-shell`: `root-bash`
- [ShellCheck](https://github.com/koalaman/shellcheck) corrections



## Preview
![image](https://user-images.githubusercontent.com/36635504/158437167-32fabfdd-ac42-4ae2-ba34-247971115a74.png)
![image](https://user-images.githubusercontent.com/36635504/158437406-4ebe56ad-f9cf-4266-b4ad-61687aa1e588.png)
