### PR TITLE
[1.x] Fixes docker-compose not found in non-bash shells

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -138,7 +138,7 @@ function sail_is_not_running {
 }
 
 # Define Docker Compose command prefix...
-if ! [ -x "$(command -v docker-compose)" ]; then
+if [ -x "$(command -v docker-compose)" ]; then
     DOCKER_COMPOSE=(docker-compose)
 else
     DOCKER_COMPOSE=(docker compose)

--- a/bin/sail
+++ b/bin/sail
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
 
-if ! [ -x "$(command -v docker-compose)" ]; then
-    shopt -s expand_aliases
-    alias docker-compose='docker compose'
-fi
-
 UNAMEOUT="$(uname -s)"
 
 # Verify operating system is supported...
@@ -143,7 +138,11 @@ function sail_is_not_running {
 }
 
 # Define Docker Compose command prefix...
-DOCKER_COMPOSE=(docker-compose)
+if ! [ -x "$(command -v docker-compose)" ]; then
+    DOCKER_COMPOSE=(docker-compose)
+else
+    DOCKER_COMPOSE=(docker compose)
+fi
 
 if [ -n "$SAIL_FILES" ]; then
     # Convert SAIL_FILES to an array...


### PR DESCRIPTION
Fixes #363 

A minimal environment to test the issue: https://gist.github.com/ribeirobreno/e37f817e7cfa60f4e20021707feeaf8c

To test: 
- Setup a new laravel install
```
    curl -s https://laravel.build/example-app | bash
    cd example-app
```
- Apply the changes
- Run `zsh`
- Run `sail` commands
