### PR TITLE
Simplify Display Help Check

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -102,11 +102,7 @@ function display_help {
 }
 
 # Proxy the "help" command...
-if [ $# -gt 0 ]; then
-    if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
-        display_help
-    fi
-else
+if [ $# -eq 0 ] || [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
     display_help
 fi
 


### PR DESCRIPTION
Reduce the nested if/else block to a simple if statement when checking if we want to display the help output.