### PR TITLE
added a new ENVIRONMENT_FILE variable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -111,8 +111,11 @@ else
 fi
 
 # Source the ".env" file so Laravel's environment variables are available...
-if [ -f ./.env ]; then
-    source ./.env
+ENVIRONMENT_FILE=${ENVIRONMENT_FILE:-"./.env"}
+ENVIRONMENT_PRESENT="no"
+if [ -f $ENVIRONMENT_FILE ]; then
+    ENVIRONMENT_PRESENT="yes"
+    source $ENVIRONMENT_FILE
 fi
 
 # Define environment variables...
@@ -142,6 +145,11 @@ if [ -x "$(command -v docker-compose)" ]; then
     DOCKER_COMPOSE=(docker-compose)
 else
     DOCKER_COMPOSE=(docker compose)
+fi
+
+# Define Docker Environment
+if [ "$ENVIRONMENT_PRESENT" == "yes" ]; then
+    DOCKER_COMPOSE+=(--env-file "$ENVIRONMENT_FILE")
 fi
 
 if [ -n "$SAIL_FILES" ]; then


### PR DESCRIPTION
This adds a new Feature to sail which lets you optionally define a ENVIRONMENT_FILE.

See #368 
-> https://docs.docker.com/compose/environment-variables/#using-the---env-file--option

Since the Option "--env-file" wasnt present before the default behaviour of docker is always parsing a ".env"-File if it's present.
So this change should not break anything - even if the `--env-file ./.env`-Option now always gets passed to docker when it's not overwritten.

See: https://docs.docker.com/compose/environment-variables/#the-env-file

---
To test:
* Setup a new laravel install

```bash
curl -s https://laravel.build/example-app | bash
cd example-app
```

* Ensure everything is still working like it did before with `sail up`
* Copy a new env file: `cp .env .env.test`
* Change i.e. the application port: `echo "APP_PORT=8001" >> .env.test`
* Ensure the Application is running on the new Port when using this env `ENVIRONMENT_FILE="./.env.test" sail up`