### PR TITLE
Create a dedicated testing database

### DIFF
--- a/database/mysql/create-testing-database.sh
+++ b/database/mysql/create-testing-database.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
+    CREATE DATABASE IF NOT EXISTS testing;
+    GRANT ALL PRIVILEGES ON testing.* TO '$MYSQL_USER'@'%';
+EOSQL

--- a/database/pgsql/create-testing-database.sql
+++ b/database/pgsql/create-testing-database.sql
@@ -1,0 +1,2 @@
+SELECT 'CREATE DATABASE testing'
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'testing')\gexec

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -39,6 +39,7 @@ class InstallCommand extends Command
 
         $this->buildDockerCompose($services);
         $this->replaceEnvVariables($services);
+        $this->configurePhpUnit();
 
         if ($this->option('devcontainer')) {
             $this->installDevContainer();
@@ -146,6 +147,21 @@ class InstallCommand extends Command
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);
+    }
+
+    /**
+     * Configure PHPUnit to use the dedicated testing database.
+     *
+     * @return void
+     */
+    protected function configurePhpUnit()
+    {
+        $phpunit = file_get_contents($this->laravel->basePath('phpunit.xml'));
+
+        $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
+        $phpunit = str_replace('<!-- <env name="DB_DATABASE" value=":memory:"/> -->', '<env name="DB_DATABASE" value="testing"/>', $phpunit);
+
+        file_put_contents($this->laravel->basePath('phpunit.xml'), $phpunit);
     }
 
     /**

--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -11,6 +11,7 @@
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
         volumes:
             - 'sail-mariadb:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
         networks:
             - sail
         healthcheck:

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -11,6 +11,7 @@
             MYSQL_ALLOW_EMPTY_PASSWORD: 1
         volumes:
             - 'sail-mysql:/var/lib/mysql'
+            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
         networks:
             - sail
         healthcheck:

--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -9,6 +9,7 @@
             POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
         volumes:
             - 'sail-pgsql:/var/lib/postgresql/data'
+            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
         networks:
             - sail
         healthcheck:


### PR DESCRIPTION
### The problem

In a default sail installation, running tests with the `RefreshDatabase` trait will empty the user's local database and log them out. This is because the trait calls `migrate:fresh`.

To reproduce:

1. Set up a project with Sail
   ```sh
   laravel new --git sail-test
   cd sail-test
   php artisan sail:install
   ./vendor/bin/sail up -d
   ./vendor/bin/sail artisan migrate
   ```
2. Allow user registration (e.g. with Breeze)
   ```sh
   ./vendor/bin/sail composer require --dev laravel/breeze
   ./vendor/bin/sail artisan breeze:install
   ./vendor/bin/sail npm install
   ./vendor/bin/sail npm run dev
   ```
3. Browse to http://localhost/register and register an account
4. Run the tests (Breeze includes tests with the `RefreshDatabase` trait)
   ```sh
   ./vendor/bin/sail test
   ```
5. Refresh the page at http://localhost and see that you're logged out and your account no longer exists.

Using SQLite for tests can be a good solution, but the lack of feature parity with MySQL et al. can be a confusing source of bugs.

### The solution

This PR configures the database containers to create an additional `testing` database. The PHPUnit configuration is updated accordingly.

I have tested this with MySQL, MariaDB, and PostgreSQL.

Note that MySQL and Maria DB need an init script to set the appropriate permissions for the user. This is not required for PostgreSQL because the `POSTGRES_USER` has superuser privileges.

### Notes

* The PHPUnit configuration may also be too brittle as it's expecting a default Laravel `phpunit.xml`. I can make this a lot smarter at the cost of code (and regex) complexity.
* The database name is currently hardcoded as `testing`. This will conflict if the users `DB_USERNAME` is already set to that, which would occur when running `laravel new testing`. It doesn't cause any failures, however, they will only get a single database which won't solve the above issue. We could use a more obscure name (e.g. `sail_testing`) or attempt to make it dynamic (e.g. `${DB_DATABASE}_testing`)
* It's probably worth mentioning the additional database in the docs - I will create a PR if this goes ahead.