### PR TITLE
Expose 8080 port for hot module replacement

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -12,6 +12,7 @@ services:
             - 'host.docker.internal:host-gateway'
         ports:
             - '${APP_PORT:-80}:80'
+            - '${HMR_PORT:-8080}:8080'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### The problem
When user run hot module replacement (HMR) with laravel-mix (`sail npm run hot`), an error "`Failed to load resource: net::ERR_CONNECTION_REFUSED`" is returned because the port is not forwarded.
### The solution
Add 8080 port forwarding.

### Ref
https://laravel-mix.com/docs/6.0/hot-module-replacement