### PR TITLE
Allow passing TZ argument from docker-compose.yml

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:21.10
 
 LABEL maintainer="Taylor Otwell"
 
+ARG TZ=UTC
 ARG WWWGROUP
 ARG NODE_VERSION=16
 ARG POSTGRES_VERSION=14
@@ -9,7 +10,7 @@ ARG POSTGRES_VERSION=14
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV TZ=UTC
+ENV TZ=$TZ
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:21.10
 
 LABEL maintainer="Taylor Otwell"
 
+ARG TZ=UTC
 ARG WWWGROUP
 ARG NODE_VERSION=16
 ARG POSTGRES_VERSION=14
@@ -9,7 +10,7 @@ ARG POSTGRES_VERSION=14
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV TZ=UTC
+ENV TZ=$TZ
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 LABEL maintainer="Taylor Otwell"
 
+ARG TZ=UTC
 ARG WWWGROUP
 ARG NODE_VERSION=16
 ARG POSTGRES_VERSION=14
@@ -9,7 +10,7 @@ ARG POSTGRES_VERSION=14
 WORKDIR /var/www/html
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV TZ=UTC
+ENV TZ=$TZ
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 


### PR DESCRIPTION
The title is pretty self-explanatory.  

At the moment, it is not possible to change the timezone without publishing sail runtimes. With this change, it would be possible to set the timezone from `docker-compose.yml` by simply adding a new argument, like so

```yml
services:
  laravel.test:
    build:
      context: ./vendor/laravel/sail/runtimes/8.1
      dockerfile: Dockerfile
      args:
        WWWGROUP: '${WWWGROUP}'
        TZ: 'America/Los_Angeles'
```