### PR TITLE
use docker compose (GO)

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -138,10 +138,10 @@ function sail_is_not_running {
 }
 
 # Define Docker Compose command prefix...
-if [ -x "$(command -v docker-compose)" ]; then
-    DOCKER_COMPOSE=(docker-compose)
-else
+if [ -x "$(command -v docker compose)" ]; then
     DOCKER_COMPOSE=(docker compose)
+else
+    DOCKER_COMPOSE=(docker-compose)
 fi
 
 if [ -n "$SAIL_FILES" ]; then


### PR DESCRIPTION
Hence `docker compose` (instead of `docker-compose`) has been released and is much more stable (it's a GO version instead of Python) and is installed with the same repo as docker its a good time to make it the default
ref: [link](https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository) it's called `docker-compose-plugin`

initial PR: [link](https://github.com/laravel/sail/pull/404)