### PR TITLE
Checks if docker compose or docker-compose is installed

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -142,7 +142,8 @@ function sail_is_not_running {
 }
 
 # Define Docker Compose command prefix...
-if [ -x "$(command -v docker compose)" ]; then
+docker compose &> /dev/null
+if [ $? == 0 ]; then
     DOCKER_COMPOSE=(docker compose)
 else
     DOCKER_COMPOSE=(docker-compose)


### PR DESCRIPTION
This commit introduced a new error for our Laravel Sail installation: https://github.com/laravel/sail/commit/1da083e30e6b0d646535c0afc2afeffdccb7181d#commitcomment-73871145

In my comment I've explained the issue.

This pull request and change contains another approach to determine if `docker compose` or `docker-compose` is installed.

As in my comment described `command -v docker compose` outputs two lines and not just one installation PATH from `docker compose`.

```
command -v docker compose
/usr/bin/docker
/usr/bin/compose
```

Maybe there is a better bash expression but this is working for me:

```
docker compose &> /dev/null
if [ $? == 0 ]; then
...
```

I've testet it with

```
sudo apt-get install docker-compose-plugin
``` 
=> uses `docker compose`

```
sudo apt-get remove docker-compose-plugin
```
 => uses `docker-compose`