### PR TITLE
Update meilisearch stub to reflect new data path

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -3,7 +3,7 @@
         ports:
             - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
         volumes:
-            - 'sail-meilisearch:/data.ms'
+            - 'sail-meilisearch:/meili_data'
         networks:
             - sail
         healthcheck:


### PR DESCRIPTION
Meilisearch, since v0.27 has updated their working data path to /meili_data. See: https://blog.meilisearch.com/whats-new-in-v0-27/

This fix resolves persistence with images that come after v0.27, including 'latest', which sail uses.
