### PR TITLE
Run supervisord with pid 1

### DIFF
--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -13,5 +13,5 @@ chmod -R ugo+rw /.composer
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else
-    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
+    exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi


### PR DESCRIPTION
### Problem
When we stop the containers, `laravel.test` is exited with code 137 (SIGKILL).
This is because supervisord is not running with pid 1.
```
$ docker-compose up
laravel.test_1  | 2022-05-28 19:13:18,824 INFO supervisord started with pid 9
$ docker-compose stop
$ docker-compose ps
        Name                   Command           State     Ports
----------------------------------------------------------------
sample_laravel.test_1   start-container         Exit 137        
sample_mysql_1          /entrypoint.sh mysqld   Exit 0    
```

### Solution
At `start-container` script, use `exec` command to run supervisord. It makes it possible to replace the current process (pid 1).
Now, supervisord is started with pid 1 and we can stop the container with exit code 0.
```
$ docker-compose up
laravel.test_1  | 2022-05-28 19:33:08,619 INFO supervisord started with pid 1
$ docker-compose stop
$ docker-compose ps
        Name                   Command           State     Ports
----------------------------------------------------------------
sample_laravel.test_1   start-container         Exit 0        
sample_mysql_1          /entrypoint.sh mysqld   Exit 0    
```
