### PR TITLE
Allow for creation of databases needed for parallel testing

### DIFF
--- a/database/mysql/create-testing-database.sh
+++ b/database/mysql/create-testing-database.sh
@@ -2,5 +2,5 @@
 
 mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS testing;
-    GRANT ALL PRIVILEGES ON testing.* TO '$MYSQL_USER'@'%';
+    GRANT ALL PRIVILEGES ON `testing%`.* TO '$MYSQL_USER'@'%';
 EOSQL


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Adjust the privileges of the `$MYSQL_USER` to allow to create any database with a `testing` prefix.
Before the default user wasn't allowed to created the databases needed by `sail test --parallel`.

The `%` characters serves as a wildcard.