### PR TITLE
Fix testing DB creation

### DIFF
--- a/database/mysql/create-testing-database.sh
+++ b/database/mysql/create-testing-database.sh
@@ -2,5 +2,5 @@
 
 mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS testing;
-    GRANT ALL PRIVILEGES ON `testing%`.* TO '$MYSQL_USER'@'%';
+    GRANT ALL PRIVILEGES ON \`testing%\`.* TO '$MYSQL_USER'@'%';
 EOSQL


### PR DESCRIPTION
This PR fixes a bug introduced in #424 that prevents the MySQL server from starting.

The backticks need to be escaped. Otherwise, the shell will try to execute the contents, resulting in the following error: 

```
/docker-entrypoint-initdb.d/10-create-testing-database.sh: line 3: testing%: command not found
ERROR 1064 (42000) at line 2: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '.* TO 'sail'@'%'' at line 1
```