### PR TITLE
Revert "Expose 8080 port for hot module replacement"

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -12,7 +12,6 @@ services:
             - 'host.docker.internal:host-gateway'
         ports:
             - '${APP_PORT:-80}:80'
-            - '${HMR_PORT:-8080}:8080'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1


### PR DESCRIPTION
Reverts laravel/sail#391

As detailed at https://github.com/laravel/sail/pull/391#issuecomment-1151983482, Laravel Mix no longer works inside _or_ outside the container without additional Mix configuration. If the user already needs to manually configure Mix, then they might as well just configure this part of their `docker-compose.yml` manually as well.

Please note that a similar feature for Vite is being added to Sail in #433, however it does not suffer the same issue because Laravel's first-party Vite plugin will automatically detect when it's inside Sail and will listen on the appropriate host. Additionally, Vite will automatically find an available port when the default is in use, and the Laravel plugin will add the correct port to the `public/hot` file, allowing Vite to be used both in and outside the container with no additional configuration.