### PR TITLE
[1.x] Publish the Vite port

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -13,6 +13,7 @@ services:
         ports:
             - '${APP_PORT:-80}:80'
             - '${HMR_PORT:-8080}:8080'
+            - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1


### PR DESCRIPTION
This PR allows the Vite development server to run inside the `laravel.test` container via `sail npm run dev`.

The Laravel Vite Plugin is configured to [automatically detect](https://github.com/laravel/vite-plugin/blob/main/src/index.ts#L85-L89) when inside Sail. It will configure Vite to listen on the container's public address to allow the port publishing to work correctly.

Note that the configuration in this PR will mean that Vite cannot run on this port _outside_ of the container while the container is running because Docker will have taken the port. This is not a problem because Vite will automatically find an available port, and our plugin will pass the correct port to Laravel via the `public/hot` file.

Also, note that the `VITE_PORT` env variable is used on both sides of the port publishing map because it will also configure our Vite plugin to listen on that port, unlike the other env variables.

Finally, note that the default port in this PR is the Vite 3 default port. It will work with Vite 2 because our plugin will default to this port when running inside Sail (see above link).