### PR TITLE
[1.x] Support persistent tinker history

### DIFF
--- a/runtimes/7.4/start-container
+++ b/runtimes/7.4/start-container
@@ -10,6 +10,10 @@ fi
 
 chmod -R ugo+rw /.composer
 
+if [ -d /home/sail/.config/psysh ]; then
+    chown sail: /home/sail/.config/psysh
+fi
+
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -10,6 +10,10 @@ fi
 
 chmod -R ugo+rw /.composer
 
+if [ -d /home/sail/.config/psysh ]; then
+    chown sail: /home/sail/.config/psysh
+fi
+
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -10,6 +10,10 @@ fi
 
 chmod -R ugo+rw /.composer
 
+if [ -d /home/sail/.config/psysh ]; then
+    chown sail: /home/sail/.config/psysh
+fi
+
 if [ $# -gt 0 ]; then
     exec gosu $WWWUSER "$@"
 else

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -94,9 +94,9 @@ class InstallCommand extends Command
                 return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
             })->map(function ($service) {
                 return "    sail-{$service}:\n        driver: local";
-            })->whenNotEmpty(function ($collection) {
-                return $collection->prepend('volumes:');
-            })->implode("\n");
+            })->push("    sail-tinker:\n        driver: local")
+            ->prepend('volumes:')
+            ->implode("\n");
 
         $dockerCompose = file_get_contents(__DIR__ . '/../../stubs/docker-compose.stub');
 

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -20,6 +20,7 @@ services:
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
         volumes:
             - '.:/var/www/html'
+            - 'sail-tinker:/home/sail/.config/psysh'
         networks:
             - sail
 {{depends}}


### PR DESCRIPTION
When using `sail tinker` the history is written to `/home/sail/.config/psysh/psysh_history`.
The containing directory is volatile, so history will be lost between container restarts.

This PR adds a named volume `sail-tinker` which is mounted at `/home/sail/.config/psysh`. Docker mounts the directory with `root:root`. To make it writable for the `sail` user, the script `start-container` was extended accordingly.