### PR TITLE
fix: fix running sail with sudo command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -123,8 +123,8 @@ fi
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
 export DB_PORT=${DB_PORT:-3306}
-export WWWUSER=${WWWUSER:-$UID}
-export WWWGROUP=${WWWGROUP:-$(id -g)}
+export WWWUSER=${WWWUSER:-$(id -u $(logname))}
+export WWWGROUP=${WWWGROUP:-$(id -g $(logname))}
 
 export SAIL_FILES=${SAIL_FILES:-""}
 export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}


### PR DESCRIPTION
# Goal
This PR will fix the problem mentioned in this [issue#81](https://github.com/laravel/sail/issues/81)  

## Problem

### What caused to this problem arise?
This problem will occur if you call `sail` command with `sudo` or use docker in rootless mode.

### Description
When a user uses `sudo` to call the `sail` command, these variables `WWWGROUP` and `WWWUSER` will set to the UID of the root user on their system (in most cases it should be 0). now if the user has its own user on the system with a different UID, the volume syncing between the host and the container will be set to the wrong number.

__Example__:

Imagine my user id is 1000, when I run the sail with `sudo` (and if I didn't set `WWWGROUP` and `WWWUSER` to my user id in the environment variable or `docker-compose.yml`), then sail's user id will set to 0 on the container. (actually it won't happen, cause the container already has the root user with the id of 0, if you check the sail's id on the container it will remain on the default value 1337).
but the actual owner of the files in the container is the one who has the id of 1000 (cause there is no user with this id on the container if you log the owner it will show the raw number that is 1000). in this situation when Laravel wants to write to a file on this directory it has no sufficient permission. and the errors about permission will throw.

I find out that there is a workaround to get the actual user when someone calls the `sail` with `sudo`. with this solution, everything will works as expected.

__**Note**__: __besides using `sudo` there is a problem with the rootless mode of docker. in the rootless mode, docker will map all the permission to the root user in the container, and I couldn't find a workaround for this. then I suggest that you mention in the document that people consider not using docker in rootless mode if they want to use Laravel sail.__