### PR TITLE
[1.x] Fixed devcontainer permissions

### DIFF
--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -15,8 +15,8 @@
 		// "onecentlin.laravel-blade"
 	],
 	"remoteUser": "sail",
+	"postCreateCommand": "chown -R 1000:1000 /var/www/html"
 	// "forwardPorts": [],
 	// "runServices": [],
-	// "postCreateCommand": "apt-get update && apt-get install -y curl",
 	// "shutdownAction": "none",
 }


### PR DESCRIPTION
## Problem
If I create a Laravel application in a DevEnvrionment (while following the [docs](https://laravel.com/docs/9.x#choosing-your-sail-services)), all file permissions inside the container are set to `root:root`, which throws permission exceptions; such as this: [https://flareapp.io/share/qm1036q5#F11](https://flareapp.io/share/qm1036q5#F11).

## Decision
I thought about what's been discussed in the issue [ #435 ] I've submitted before, and I don't think documentation is the solution. Since, to my understanding, there's **no other way** to work with the DevContainer files from VSC nor access them from the browser than owning them by `sail` user! And if there is one, then I'd love to learn about it. 🙂

So why wouldn't we add a line *somewhere* instead of forcing the user to learn about a lot of Linux commands, Laravel file structure and permissions, and before even reaching the app's home page; possibly!

## Solution
Also considering the weird situation, it seems like adding a command in the [`start-container`](https://github.com/laravel/sail/blob/1.x/runtimes/8.1/start-container) file would feel intrusive, since there's still that regular `sail` use-case without a DevContainer!

Therefore, I've utilized the commented-out [life-cycle](https://code.visualstudio.com/docs/remote/devcontainerjson-reference#_lifecycle-scripts) line in [`devcontainer.json`](https://github.com/laravel/sail/blob/1.x/stubs/devcontainer.stub#L20) itself to set the permissions manually. 

## Setup
I've done the following via Ubuntu 22.04 and VSC with [Remote Development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension.

### Steps
- ```bash
  curl -s "https://laravel.build/example-app?devcontainer" | bash
  code -r example-app/
  ```
  - If the `Remote-Containers: Reopen in Container` command is used without the "fix", and once the setup is done, all files are owned by `root:root`; throwing the exceptions shown at the top.
  - If the `"postCreateCommand": "chown -R 1000:1000 /var/www/html"` was added first in `devcontainer.json`, and then built the container instead; or possibly just ran `Remote-Containers: Rebuild Without Cache and Reopen in Container`; then the files are owned by `sail:sail` and everybody is happy. 🙃
  
    ![2022-06-23_11-00](https://user-images.githubusercontent.com/81492351/175264517-eaf1524c-0287-4811-a34f-b060d81d841a.png)

  