### PR TITLE
Fix 7.4 runtime issue where PHP 8.1 is loaded

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -39,6 +39,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/pgdg.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt impish-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get remove -y --purge php8.1-cli php8.1-common php8.1-opcache php8.1-phpdbg php8.1-readline \
     && apt-get update \
     && apt-get install -y yarn \
     && apt-get install -y mysql-client \


### PR DESCRIPTION
This fixes an issue where, for some reason, PHP 8.1 modules are accidentally installed on the 7.4 runtime and thus enabling PHP 8.1 by default. By removing these again explicitly, we get 7.4 to run by default again.

Fixes https://github.com/laravel/sail/issues/442