### PR TITLE
Fix splitting SAIL_FILES into array

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -152,7 +152,7 @@ fi
 
 if [ -n "$SAIL_FILES" ]; then
     # Convert SAIL_FILES to an array...
-    SAIL_FILES=("${SAIL_FILES//:/ }")
+    IFS=':' read -ra SAIL_FILES <<< "$SAIL_FILES"
 
     for FILE in "${SAIL_FILES[@]}"; do
         if [ -f "$FILE" ]; then


### PR DESCRIPTION
This addresses the same issue as #425 and #427.

With the current version, having
```
SAIL_FILES=docker-compose.yml:docker-compose.override.yml
```
in .env results in this error:
```
Unable to find Docker Compose file: 'docker-compose.yml docker-compose.override.yml'
```

It could be fixed by removing the quotes as suggested in #425, but this was rejected in #427.
The screenshot posted by @WalterWoshid in #427 suggested that there are more robust ways of splitting a string into an array, which led me to an alternative solution:
```bash
IFS=':' read -ra SAIL_FILES <<< "$SAIL_FILES"
```
