### PR TITLE
makes it possible to use a proxy for the gnupg command

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
     && echo "keyserver hkp://keyserver.ubuntu.com:80" >> ~/.gnupg/dirmngr.conf \
     && gpg --recv-key 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c \
     && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c > /usr/share/keyrings/ppa_ondrej_php.gpg \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
     && echo "keyserver hkp://keyserver.ubuntu.com:80" >> ~/.gnupg/dirmngr.conf \
     && gpg --recv-key 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c \
     && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c > /usr/share/keyrings/ppa_ondrej_php.gpg \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -18,6 +18,7 @@ RUN apt-get update \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
+    && echo "honor-http-proxy" >> ~/.gnupg/dirmngr.conf \
     && echo "keyserver hkp://keyserver.ubuntu.com:80" >> ~/.gnupg/dirmngr.conf \
     && gpg --recv-key 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c \
     && gpg --export 0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c > /usr/share/keyrings/ppa_ondrej_php.gpg \


### PR DESCRIPTION
The gnupg command can't connect to the keyserver when the host is behind a proxy.

Adding the option "honor-http-proxy" in the file ```~/.gnupg/dirmngr.conf```, _"if the environment variable http_proxy has been set, use its value to access HTTP servers"_ (https://www.gnupg.org/documentation/manuals/gnupg/Dirmngr-Options.html)

In this way, if the user is behind a proxy, just add to the file ```docker-compose.yaml```, in services>laravel.test>build>args, the variables, like:
```yaml
            args:
                WWWGROUP: '${WWWGROUP}'
                HTTPS_PROXY: '${https_proxy:-}'
                HTTP_PROXY: '${http_proxy:-}'
                FTP_PROXY: '${ftp_proxy:-}'
                NO_PROXY: '${no_proxy:-}'
```
So the ```apt``` and ```gpg``` commands will work normally behind a proxy.
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
