### PR TITLE
Custom shell binary with APP_SHELL

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -431,7 +431,7 @@ elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bash "$@")
+        ARGS+=("$APP_SERVICE" "${APP_BASH:=bash}" "$@")
     else
         sail_is_not_running
     fi
@@ -443,7 +443,7 @@ elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bash "$@")
+        ARGS+=("$APP_SERVICE" "${APP_BASH:=bash}" "$@")
     else
         sail_is_not_running
     fi


### PR DESCRIPTION
This change allows developers that use a custom Dockerfile to build from an image without bash (i.e. alpine) to be able to use the command `sail bash`, `sail shell`, `sail root-bash` and `sail root-shell` as long as the env var `APP_BASH` is set to an existing shell within the container. 

It defaults to `bash` so the current behavior will continue unaltered. 