### PR TITLE
[1.x] Build and pull images on install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -249,7 +249,7 @@ class InstallCommand extends Command
             }
         }
 
-        $process->run(function ($type, $line) {
+        return $process->run(function ($type, $line) {
             $this->output->write('    '.$line);
         });
     }

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -26,6 +26,23 @@ class InstallCommand extends Command
     protected $description = 'Install Laravel Sail\'s default Docker Compose file';
 
     /**
+     * The available services that may be installed
+     *
+     * @var array<string>
+     */
+    protected $services = [
+        'mysql',
+        'pgsql',
+        'mariadb',
+        'redis',
+        'memcached',
+        'meilisearch',
+        'minio',
+        'mailhog',
+        'selenium',
+    ];
+
+    /**
      * Execute the console command.
      *
      * @return int|null
@@ -38,6 +55,12 @@ class InstallCommand extends Command
             $services = ['mysql', 'redis', 'selenium', 'mailhog'];
         } else {
             $services = $this->gatherServicesWithSymfonyMenu();
+        }
+
+        if ($invalidServices = array_diff($services, $this->services)) {
+            $this->error('Invalid services ['.implode(',', $invalidServices).'].');
+
+            return 1;
         }
 
         $this->buildDockerCompose($services);
@@ -62,17 +85,7 @@ class InstallCommand extends Command
      */
     protected function gatherServicesWithSymfonyMenu()
     {
-        return $this->choice('Which services would you like to install?', [
-             'mysql',
-             'pgsql',
-             'mariadb',
-             'redis',
-             'memcached',
-             'meilisearch',
-             'minio',
-             'mailhog',
-             'selenium',
-         ], 0, null, true);
+        return $this->choice('Which services would you like to install?', $this->services, 0, null, true);
     }
 
     /**
@@ -85,7 +98,7 @@ class InstallCommand extends Command
     {
         $depends = collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio', 'selenium']);
+                return in_array($service, $this->services);
             })->map(function ($service) {
                 return "            - {$service}";
             })->whenNotEmpty(function ($collection) {

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -94,9 +94,7 @@ class InstallCommand extends Command
     protected function buildDockerCompose(array $services)
     {
         $depends = collect($services)
-            ->filter(function ($service) {
-                return in_array($service, $this->services);
-            })->map(function ($service) {
+            ->map(function ($service) {
                 return "            - {$service}";
             })->whenNotEmpty(function ($collection) {
                 return $collection->prepend('depends_on:');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -15,8 +15,7 @@ class InstallCommand extends Command
      */
     protected $signature = 'sail:install
                 {--with= : The services that should be included in the installation}
-                {--devcontainer : Create a .devcontainer configuration directory}
-                {--prepare : Prepare the installation by building and pulling necessary images}';
+                {--devcontainer : Create a .devcontainer configuration directory}';
 
     /**
      * The console command description.
@@ -73,9 +72,7 @@ class InstallCommand extends Command
 
         $this->info('Sail scaffolding installed successfully.');
 
-        if ($this->option('prepare')) {
-            return $this->prepareInstallation($services);
-        }
+        return $this->prepareInstallation($services);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -25,7 +25,7 @@ class InstallCommand extends Command
     protected $description = 'Install Laravel Sail\'s default Docker Compose file';
 
     /**
-     * The available services that may be installed
+     * The available services that may be installed.
      *
      * @var array<string>
      */
@@ -210,10 +210,10 @@ class InstallCommand extends Command
     }
 
     /**
-     * Prepare the installation by building and pulling necessary images.
+     * Prepare the installation by pulling and building any necessary images.
      *
      * @param  array  $services
-     * return int|null
+     * @return int|null
      */
     protected function prepareInstallation($services)
     {
@@ -223,7 +223,7 @@ class InstallCommand extends Command
         ]);
 
         if ($status !== 0) {
-            $this->warn('Unable to build and pull images. Is Docker installed and running?');
+            $this->warn('Unable to download and build your Sail images. Is Docker installed and running?');
 
             return 1;
         }


### PR DESCRIPTION
This PR updates the `sail:install` command so that it will download and build the required Docker images upon installation.

When running `sail up` on a fresh machine, it can take more than 5 minutes to download and build everything before it transitions to the serving phase. If you're unfamiliar with Docker's output, it is not immediately apparent when the downloading and building have finished and the serving has begun.

While this won't decrease waiting times, it moves the "slow part" from the up command to the install command, where it's far more apparent when it has been completed. When running the up command, everything can start straight away.

Note that the database containers go through a brief "first run" setup phase where the initial user and databases are created. While users may immediately access their `laravel.test` container, they may briefly encounter a database connection error if they're quick enough to hit the database before it's ready.

I have also added some validation to the `--with` option to ensure that we only pass sanitized data to the `sail pull` shell command. In doing so, I noticed that we were not adding a "depends_on" entry for memcached, which I have also resolved.

**Happy path**

![image](https://user-images.githubusercontent.com/4977161/184815524-2c56f1ba-66af-4d38-912b-c383930fd5a1.png)

**With Docker service stopped**

![image](https://user-images.githubusercontent.com/4977161/184815797-3bae7739-15d1-4cba-8445-fe1e3ce22643.png)

(The output from the `sail pull` and `sail build` commands is passed through to help the developer debug why the install failed, as it could be various issues such as no network)

If this is merged, I will PR the docs to remove this section from https://laravel.com/docs/9.x#getting-started-on-macos, and maybe mention the time under the install command instead:

![image](https://user-images.githubusercontent.com/4977161/184829198-7a31f6ce-92b5-424b-8963-32cdc963d50c.png)