### PR TITLE
[1.x] Don't error when docker is not available

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -72,7 +72,7 @@ class InstallCommand extends Command
 
         $this->info('Sail scaffolding installed successfully.');
 
-        return $this->prepareInstallation($services);
+        $this->prepareInstallation($services);
     }
 
     /**
@@ -211,22 +211,23 @@ class InstallCommand extends Command
      * Prepare the installation by pulling and building any necessary images.
      *
      * @param  array  $services
-     * @return int|null
+     * @return void
      */
     protected function prepareInstallation($services)
     {
+        // Ensure docker is installed
+        if ($this->runCommands(['docker info > /dev/null 2>&1']) !== 0) {
+            return;
+        }
+
         $status = $this->runCommands([
             './vendor/bin/sail pull '.implode(' ', $services),
             './vendor/bin/sail build',
         ]);
 
-        if ($status !== 0) {
-            $this->warn('Unable to download and build your Sail images. Is Docker installed and running?');
-
-            return 1;
+        if ($status === 0) {
+            $this->info('Sail images installed successfully.');
         }
-
-        $this->info('Sail images installed successfully.');
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -215,7 +215,7 @@ class InstallCommand extends Command
      */
     protected function prepareInstallation($services)
     {
-        // Ensure docker is installed
+        // Ensure docker is installed...
         if ($this->runCommands(['docker info > /dev/null 2>&1']) !== 0) {
             return;
         }


### PR DESCRIPTION
This PR fixes a misleading error message caused by #467.

When installing Laravel via laravel.build, the `sail:install` command is run _inside_ a temporary container ([source](https://github.com/laravel/sail-server/blob/d251ffb805b893fe23442f49dddce791b10c1348/resources/scripts/php.sh#L14)). When inside this container, the `docker pull` and `docker build` commands fail and display a message saying "Is Docker running?" which is misleading. The installation continues regardless of this error, leaving the installation in the same state as prior to #467.

It's non-trivial to run Docker commands _inside_ a container, so this PR just adds a guard that silently returns if Docker is not available, instead of displaying the error. The logic for determining the presence of Docker is the same as [the sail command itself](https://github.com/laravel/sail/blob/1f870bcf7d9083bb09de0f25291ecd52f4942ec2/bin/sail#L171-L176).

I have created a [separate PR](https://github.com/laravel/sail-server/pull/11) for laravel.build that adds the functionality from #467 when using that installation method.