### PR TITLE
Syncing local environments using a `serve` script

### DIFF
--- a/stubs/serve-npm.stub
+++ b/stubs/serve-npm.stub
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Fail the whole script if any command fails
+set -euo pipefail
+trap "echo \"[INFO] To stop the docker container you need to run: vendor/bin/sail down\"" EXIT
+
+FRESH=false
+
+# Determine if the environment should be refreshed
+if [ $# -eq 1 ] && [ $1 == '--fresh' ]
+then
+    rm -rf node_modules
+    rm -rf vendor
+    rm -f storage/sail/composer.lock
+    rm -f storage/sail/package-lock.json
+    rm -f storage/sail/docker-compose.yml
+    rm -f .env
+fi
+
+# Create environment file if it doesn't exist yet
+if [ ! -f .env ]
+then
+    cp .env.example .env
+    FRESH=true
+fi
+
+# Install needed composer dependencies for Laravel Sail
+if [ ! -f vendor/bin/sail ]
+then
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v $(pwd):/var/www/html \
+        -w /var/www/html \
+        laravelsail/php81-composer:latest \
+        composer install --ignore-platform-reqs
+fi
+
+# Install needed composer dependencies for Laravel Sail
+if [ ! -f vendor/bin/sail ]
+then
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v $(pwd):/var/www/html \
+        -w /var/www/html \
+        laravelsail/php81-composer:latest \
+        composer install --ignore-platform-reqs
+fi
+
+if [ ! -f storage/sail/docker-compose.yml ] || ! cmp --silent -- "docker-compose.yml" "storage/sail/docker-compose.yml"
+then
+    vendor/bin/sail stop
+    vendor/bin/sail build --no-cache --pull
+
+    cp docker-compose.yml storage/sail/docker-compose.yml
+fi
+
+# Get Laravel Sail up and running in the background
+vendor/bin/sail up -d --wait
+
+# Install NPM dependencies if not installed yet
+if [ ! -d node_modules ]
+then
+    vendor/bin/sail npm install
+
+    # Save currently installed dependencies
+    cp package-lock.json storage/sail/package-lock.json
+fi
+
+# Install latest composer dependencies, if out of sync
+if ! cmp --silent -- "composer.lock" "storage/sail/composer.lock"
+then
+    vendor/bin/sail composer install
+
+    cp composer.lock storage/sail/composer.lock
+fi
+
+# Install latest npm dependencies, if out of sync
+if ! cmp --silent -- "package-lock.json" "storage/sail/package-lock.json"
+then
+    vendor/bin/sail npm install
+
+    # Save currently installed dependencies
+    cp package-lock.json storage/sail/package-lock.json
+fi
+
+# Migrate Database to the newest version
+if $FRESH
+then
+    vendor/bin/sail artisan migrate:fresh --seed
+else
+    vendor/bin/sail artisan migrate
+fi
+
+# Start the Development Server
+vendor/bin/sail npm run dev

--- a/stubs/serve-yarn.stub
+++ b/stubs/serve-yarn.stub
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+# Fail the whole script if any command fails
+set -euo pipefail
+trap "echo \"[INFO] To stop the docker container you need to run: vendor/bin/sail down\"" EXIT
+
+FRESH=false
+
+# Determine if the environment should be refreshed
+if [ $# -eq 1 ] && [ $1 == '--fresh' ]
+then
+    rm -rf node_modules
+    rm -rf vendor
+    rm -f storage/sail/composer.lock
+    rm -f storage/sail/yarn.lock
+    rm -f storage/sail/docker-compose.yml
+    rm -f .env
+fi
+
+# Create environment file if it doesn't exist yet
+if [ ! -f .env ]
+then
+    cp .env.example .env
+    FRESH=true
+fi
+
+# Install needed composer dependencies for Laravel Sail
+if [ ! -f vendor/bin/sail ]
+then
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v $(pwd):/var/www/html \
+        -w /var/www/html \
+        laravelsail/php81-composer:latest \
+        composer install --ignore-platform-reqs
+fi
+
+# Install needed composer dependencies for Laravel Sail
+if [ ! -f vendor/bin/sail ]
+then
+    docker run --rm \
+        -u "$(id -u):$(id -g)" \
+        -v $(pwd):/var/www/html \
+        -w /var/www/html \
+        laravelsail/php81-composer:latest \
+        composer install --ignore-platform-reqs
+fi
+
+if [ ! -f storage/sail/docker-compose.yml ] || ! cmp --silent -- "docker-compose.yml" "storage/sail/docker-compose.yml"
+then
+    vendor/bin/sail stop
+    vendor/bin/sail build --no-cache --pull
+
+    cp docker-compose.yml storage/sail/docker-compose.yml
+fi
+
+# Get Laravel Sail up and running in the background
+vendor/bin/sail up -d --wait
+
+# Install yarn dependencies if not installed yet
+if [ ! -d node_modules ]
+then
+    vendor/bin/sail yarn install --frozen-lockfile
+
+    # Save currently installed dependencies
+    cp yarn.lock storage/sail/yarn.lock
+fi
+
+# Install latest composer dependencies, if out of sync
+if ! cmp --silent -- "composer.lock" "storage/sail/composer.lock"
+then
+    vendor/bin/sail composer install
+
+    cp composer.lock storage/sail/composer.lock
+fi
+
+# Install latest yarn dependencies, if out of sync
+if ! cmp --silent -- "yarn.lock" "storage/sail/yarn.lock"
+then
+    vendor/bin/sail yarn install --frozen-lockfile
+
+    # Save currently installed dependencies
+    cp yarn.lock storage/sail/yarn.lock
+fi
+
+# Migrate Database to the newest version
+if $FRESH
+then
+    vendor/bin/sail artisan migrate:fresh --seed
+else
+    vendor/bin/sail artisan migrate
+fi
+
+# Start the Development Server
+vendor/bin/sail yarn run dev


### PR DESCRIPTION
## Idea:

In my laravel projects which use sail I often add a `serve` script, which helps with dependency management and setup for local environments.

The serve script does basically the following:

1. Copy `.env.example` to `.env` if `.env` doesn't exist yet
2. Install needed sail binaries using a temporary docker container if they don't exist
3. Build docker container or rebuild docker container if changes to `docker-compose.yml` were made
4. Start docker container using `sail up -d --wait`
5. Install node dependencies if they don't exist or `package-lock.json` or `yarn.lock` is out of sync
6. Install composer dependencies if they don't exist or `composer.lock` is out of sync
7. Migrate Database (on fresh installation even with the seed option)
8. Run the Vite dev server

There also is a `--fresh` option for deleting the current env and setting it up again

The script would be published to the root folder and run with `./serve` or it could be published to a new `bin` folder and could be run using `bin/serve`

## Feedback

For now I only submitted the raw scripts for feedback.
- Do you want the scripts
- What should be changed
- etc.

Therefor some things are missing.

## What still needs to be done

- Publishing the scripts
- Creating the folder `storage/sail` and with a gitignore for determining if the environment are out of sync


Something which could also be done:
- Determine based on the `package-lock.json` or `yarn.lock` file if `npm` and `yarn` are used, which would result in one less script.