### PR TITLE
Adds Laravel scheduler support using the cron

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 cron \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
@@ -52,10 +52,14 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php7.4
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
+COPY cron/scheduler /etc/cron.d/scheduler
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/7.4/cli/conf.d/99-sail.ini
-RUN chmod +x /usr/local/bin/start-container
+
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler \
+    && chmod +x /usr/local/bin/start-container
 
 EXPOSE 8000
 

--- a/runtimes/7.4/cron/scheduler
+++ b/runtimes/7.4/cron/scheduler
@@ -1,0 +1,1 @@
+* * * * * sail cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+user=root
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 cron \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
@@ -54,10 +54,14 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
+COPY cron/scheduler /etc/cron.d/scheduler
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
-RUN chmod +x /usr/local/bin/start-container
+
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler \
+    && chmod +x /usr/local/bin/start-container
 
 EXPOSE 8000
 

--- a/runtimes/8.0/cron/scheduler
+++ b/runtimes/8.0/cron/scheduler
@@ -1,0 +1,1 @@
+* * * * * sail cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+user=root
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 cron \
     && mkdir -p ~/.gnupg \
     && chmod 600 ~/.gnupg \
     && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
@@ -53,10 +53,14 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
+COPY cron/scheduler /etc/cron.d/scheduler
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
-RUN chmod +x /usr/local/bin/start-container
+
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler \
+    && chmod +x /usr/local/bin/start-container
 
 EXPOSE 8000
 

--- a/runtimes/8.1/cron/scheduler
+++ b/runtimes/8.1/cron/scheduler
@@ -1,0 +1,1 @@
+* * * * * sail cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+user=root
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail


### PR DESCRIPTION
This PR adds support for Laravel's task scheduling using the cron jobs. Support added for PHP version `7.4`, `8.0` and `8.1`.