### PR TITLE
[1.x] Publish Selenium port

### DIFF
--- a/stubs/selenium.stub
+++ b/stubs/selenium.stub
@@ -1,5 +1,7 @@
     selenium:
         image: 'selenium/standalone-chrome'
+        ports:
+            - '${FORWARD_SELENIUM_PORT:-7900}:7900'
         volumes:
             - '/dev/shm:/dev/shm'
         networks:


### PR DESCRIPTION
This PR publishes the port that is used by the container to run noVNC. This feature is described in the documentation of the Selenium project in the sections [Quick start](https://github.com/SeleniumHQ/docker-selenium#quick-start) and [Using your browser](https://github.com/SeleniumHQ/docker-selenium#using-your-browser-no-vnc-client-is-needed).

This allows users inspect visually container activity with their browser. This is very useful when debugging automated tests with [Laravel Dusk](https://laravel.com/docs/9.x/dusk#introduction). The user will see a browser running in a container like this:

![noVNC](https://user-images.githubusercontent.com/44947427/192713124-13641d69-4716-4611-b45d-d175f133c0b7.png)

My next step is to update the Laravel Dusk documentation to describe this feature.