### PR TITLE
[1.x] Add extra hosts to Selenium

### DIFF
--- a/stubs/selenium.stub
+++ b/stubs/selenium.stub
@@ -1,5 +1,7 @@
     selenium:
         image: 'selenium/standalone-chrome'
+        extra_hosts:
+            - 'host.docker.internal:host-gateway'
         volumes:
             - '/dev/shm:/dev/shm'
         networks:


### PR DESCRIPTION
This PR adds an `extra_hosts` in the same way as it [was done earlier](https://github.com/laravel/sail/pull/222) for the `laravel.test` container.

In my case, this was required to run Laravel Dusk automated tests for a Next.js site that was running separately from the Laravel application. I think there are other uses for this as well.