### PR TITLE
change minio stub for new version

### DIFF
--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -6,11 +6,12 @@
         environment:
             MINIO_ROOT_USER: 'sail'
             MINIO_ROOT_PASSWORD: 'password'
+            MINIO_VOLUMES: "/mnt/data"
         volumes:
-            - 'sail-minio:/data/minio'
+            - 'sail-minio:/mnt/data'
         networks:
             - sail
-        command: minio server /data/minio --console-address ":8900"
+        command: minio server --console-address ":8900"
         healthcheck:
             test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
             retries: 3


### PR DESCRIPTION
For new version of minio, old run command not work for me so I changed it according to their documentation.