### PR TITLE
Fix usage of none for services list

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -220,13 +220,24 @@ class InstallCommand extends Command
             return;
         }
 
+	    // Pull images only if any needed
+	    if (count($services) > 0)
+	    {
+	        $status = $this->runCommands([
+                './vendor/bin/sail pull '.implode(' ', $services),
+            ]);
+            
+            if ($status === 0) {
+                $this->info('Sail images installed successfully.');
+            }
+	    }
+
         $status = $this->runCommands([
-            './vendor/bin/sail pull '.implode(' ', $services),
             './vendor/bin/sail build',
         ]);
 
         if ($status === 0) {
-            $this->info('Sail images installed successfully.');
+            $this->info('Sail build successful.');
         }
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -220,17 +220,16 @@ class InstallCommand extends Command
             return;
         }
 
-	    // Pull images only if any needed
-	    if (count($services) > 0)
-	    {
-	        $status = $this->runCommands([
+        // Pull images only if any needed
+        if (count($services) > 0) {
+            $status = $this->runCommands([
                 './vendor/bin/sail pull '.implode(' ', $services),
             ]);
-            
+
             if ($status === 0) {
                 $this->info('Sail images installed successfully.');
             }
-	    }
+        }
 
         $status = $this->runCommands([
             './vendor/bin/sail build',

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -220,7 +220,6 @@ class InstallCommand extends Command
             return;
         }
 
-        // Pull images only if any needed
         if (count($services) > 0) {
             $status = $this->runCommands([
                 './vendor/bin/sail pull '.implode(' ', $services),


### PR DESCRIPTION
`php artisan sail:install --with=none` not handled properly

the `none` option leaves an empty `$services` array.
However this array is not checked before trying to pull related docker images before the build.
The fix checks whether $services has some entries, if not skips image pulling process and handles build of the container.
