### PR TITLE
Kill `artisan-serve` command when environment file has been modified

### DIFF
--- a/runtimes/7.4/start-environment-monitoring
+++ b/runtimes/7.4/start-environment-monitoring
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+lastKnownModification=$(date -r /var/www/html/.env "+%s")
+while true; do
+    sleep 1
+
+    lastModified=$(date -r /var/www/html/.env "+%s")
+
+    if [ $lastModified -gt $lastKnownModification ]; then
+        lastKnownModification=$lastModified
+        /usr/bin/php -d variables_order=EGPCS /var/www/html/artisan optimize:clear
+        pgrep -fa server.php | cut -d ' ' -f 1 | xargs kill
+    fi
+done

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:monitor]
+command=/bin/bash start-environment-monitoring
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80 --no-reload
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/runtimes/8.0/start-environment-monitoring
+++ b/runtimes/8.0/start-environment-monitoring
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+lastKnownModification=$(date -r /var/www/html/.env "+%s")
+while true; do
+    sleep 1
+
+    lastModified=$(date -r /var/www/html/.env "+%s")
+
+    if [ $lastModified -gt $lastKnownModification ]; then
+        lastKnownModification=$lastModified
+        /usr/bin/php -d variables_order=EGPCS /var/www/html/artisan optimize:clear
+        pgrep -fa server.php | cut -d ' ' -f 1 | xargs kill
+    fi
+done

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:monitor]
+command=/bin/bash start-environment-monitoring
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80 --no-reload
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -54,9 +54,11 @@ RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 
 COPY start-container /usr/local/bin/start-container
+COPY start-environment-monitoring /usr/local/bin/start-environment-monitoring
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
+RUN chmod +x /usr/local/bin/start-environment-monitoring
 
 EXPOSE 8000
 

--- a/runtimes/8.1/start-environment-monitoring
+++ b/runtimes/8.1/start-environment-monitoring
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+lastKnownModification=$(date -r /var/www/html/.env "+%s")
+while true; do
+    sleep 1
+
+    lastModified=$(date -r /var/www/html/.env "+%s")
+
+    if [ $lastModified -gt $lastKnownModification ]; then
+        lastKnownModification=$lastModified
+        pid=$(ps -ef | grep -v grep | grep 'server.php' | awk '{print $2}')
+        kill $pid
+    fi
+done

--- a/runtimes/8.1/start-environment-monitoring
+++ b/runtimes/8.1/start-environment-monitoring
@@ -8,7 +8,7 @@ while true; do
 
     if [ $lastModified -gt $lastKnownModification ]; then
         lastKnownModification=$lastModified
-        pid=$(ps -ef | grep -v grep | grep 'server.php' | awk '{print $2}')
-        kill $pid
+        /usr/bin/php -d variables_order=EGPCS /var/www/html/artisan optimize:clear
+        pgrep -fa server.php | cut -d ' ' -f 1 | xargs kill
     fi
 done

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -5,7 +5,16 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80 --no-reload
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:monitor]
+command=/bin/bash start-environment-monitoring
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout

--- a/runtimes/8.2/start-environment-monitoring
+++ b/runtimes/8.2/start-environment-monitoring
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+lastKnownModification=$(date -r /var/www/html/.env "+%s")
+while true; do
+    sleep 1
+
+    lastModified=$(date -r /var/www/html/.env "+%s")
+
+    if [ $lastModified -gt $lastKnownModification ]; then
+        lastKnownModification=$lastModified
+        /usr/bin/php -d variables_order=EGPCS /var/www/html/artisan optimize:clear
+        pgrep -fa server.php | cut -d ' ' -f 1 | xargs kill
+    fi
+done

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:monitor]
+command=/bin/bash start-environment-monitoring
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -5,7 +5,7 @@ logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
 [program:php]
-command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80 --no-reload
 user=sail
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
`artisan serve` command is constantly watching if `.env` file has changed or not. Downside is that even if change is detected, not all php get's reloaded, only php server is reloaded, and some of environment variables are not updated on reload.

For example changing `APP_ENV` value, change is detected by `artisan serve` command and it restarts php server, but `APP_ENV` value does not change. Change only takes affect after docker container is restarted (or whole artisan command is killed and restarted).

Change that I've made starts 'artisan serve' command without active watch on `.env`, but started second supervisor command, to watch if `.env` has changed outside, and if it detects change it kills `artisan serve` and lets supervisor to restart it. This change always loads new environment values after change, without need of restarting docker container.

This might be not the best solution, but it works and saves some time, because it's faster to restart only serve command, rather than all docker container. Also it fixes for new developers, when they update their environment, it looks like that server has restarted, but some values are cached...

If you are interested in this change, I can apply it to other php versions.