### PR TITLE
if XDEBUG_MODE contains `coverage` pass it as env variable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -269,6 +269,9 @@ elif [ "$1" == "test" ]; then
 
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
+        [[ "$XDEBUG_MODE" == *"coverage"* ]] && {
+            ARGS+=(-e XDEBUG_MODE=$XDEBUG_MODE)
+        }
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" php artisan test "$@")
     else


### PR DESCRIPTION
To generate code coverage with xdebug we need to pass `coverage` to XDEBUG_MODE