### PR TITLE
add Caddy service for SSL reverse proxy with Laravel Sail

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -226,10 +226,12 @@ class InstallCommand extends Command
 
             $domain = parse_url(config('app.url'), PHP_URL_HOST);
 
-            file_put_contents(
-                $this->laravel->basePath('Caddyfile'),
-                str_replace('localhost', $domain, file_get_contents(__DIR__ . '/../../sslproxy/Caddyfile'))
-            );
+            $caddyfile = file_get_contents(__DIR__ . '/../../sslproxy/Caddyfile');
+
+            $caddyfile = str_replace('localhost', $domain, $caddyfile);
+            $caddyfile = str_replace('443', config('app.secure_port'), $caddyfile);
+
+            file_put_contents($this->laravel->basePath('Caddyfile'), $caddyfile);
         }
     }
 

--- a/sslproxy/CaddyProxyController.php
+++ b/sslproxy/CaddyProxyController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class CaddyProxyController extends Controller
+{
+    public function verifyDomain(Request $request)
+    {
+        $authorizedDomains = [
+            config('app.service'),
+            'localhost',
+            '127.0.0.1',
+            // Add subdomains here
+        ];
+
+        if (in_array($request->query('domain'), $authorizedDomains)) {
+            return response('Domain Authorized');
+        }
+
+        // Abort if there's no 200 response returned above
+        abort(503);
+    }
+}

--- a/sslproxy/Caddyfile
+++ b/sslproxy/Caddyfile
@@ -1,0 +1,22 @@
+{
+    on_demand_tls {
+        ask http://localhost/domain-verify
+    }
+    local_certs
+}
+
+:443 {
+    tls internal {
+        on_demand
+    }
+
+    reverse_proxy localhost {
+        header_up Host {host}
+        header_up X-Real-IP {remote}
+        header_up X-Forwarded-For {remote}
+        header_up X-Forwarded-Port {server_port}
+        header_up X-Forwarded-Proto {scheme}
+
+        health_timeout 5s
+    }
+}

--- a/sslproxy/appconfig.stub
+++ b/sslproxy/appconfig.stub
@@ -1,0 +1,14 @@
+    /*
+    |--------------------------------------------------------------------------
+    | Application Service
+    |--------------------------------------------------------------------------
+    |
+    | The APP_SERVICE environment variable is used when the default docker
+    | service name is changed from its default 'laravel.test' value.
+    | Laravel Sail will fail to start if there is a mismatch.
+    |
+    */
+
+    'service' => env('APP_SERVICE', 'laravel.test'),
+
+];

--- a/sslproxy/appconfig.stub
+++ b/sslproxy/appconfig.stub
@@ -11,4 +11,16 @@
 
     'service' => env('APP_SERVICE', 'laravel.test'),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Application Secure Port
+    |--------------------------------------------------------------------------
+    |
+    | The APP_SECURE_PORT environment variable is used to specify an alternate
+    | port to use for secure connections. If unset, the default 443 is used.
+    |
+    */
+
+    'secure_port' => env('APP_SECURE_PORT)', '443'),
+
 ];

--- a/sslproxy/routes/web.php
+++ b/sslproxy/routes/web.php
@@ -1,0 +1,3 @@
+<?php
+
+Route::get('/domain-verify', [App\Http\Controllers\CaddyProxyController::class, 'verifyDomain']);

--- a/sslproxy/routes/web.php
+++ b/sslproxy/routes/web.php
@@ -1,3 +1,0 @@
-<?php
-
-Route::get('/domain-verify', [App\Http\Controllers\CaddyProxyController::class, 'verifyDomain']);

--- a/stubs/caddy.stub
+++ b/stubs/caddy.stub
@@ -1,0 +1,12 @@
+    caddy:
+        image: caddy:latest
+        restart: unless-stopped
+        ports:
+            - '${APP_PORT:-80}:80'
+            - '${APP_SECURE_PORT:-443}:443'
+        volumes:
+            - './Caddyfile:/etc/caddy/Caddyfile'
+            - sail-caddy:/data
+            - sail-caddy:/config
+        networks:
+            - sail


### PR DESCRIPTION
I've seen a number of requests around the web for ways to make SSL work with Laravel Sail. I recently came across the same need and getting it working wasn't terribly difficult.

The solution uses Caddy as a reverse SSL proxy by leveraging its Automatic HTTPS feature.

Complete details on this solution can be found in [this gist](https://gist.github.com/Nilpo/e88d9d43623876921854d38851cd37e8).

The Caddy service uses the same installation mechanism as the other docker services. It also fully supports use of the APP_SECURE_PORT environment variable.