### PR TITLE
Update PHP 8.2 Runtime

### DIFF
--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -30,8 +30,9 @@ RUN apt-get update \
        php8.2-xml php8.2-zip php8.2-bcmath php8.2-soap \
        php8.2-intl php8.2-readline \
        php8.2-ldap \
-    #    php8.2-msgpack php8.2-igbinary php8.2-redis php8.2-swoole \
-    #    php8.2-memcached php8.2-pcov php8.2-xdebug \
+       php8.2-msgpack php8.2-igbinary php8.2-redis php8.2-swoole \
+       php8.2-memcached php8.2-xdebug \
+    #    php8.2-pcov \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sLS https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \


### PR DESCRIPTION
I checked all PHP8.2 extensions and it seems like only `php8.2-pocv` is still missing, therefor I uncommented all other extensions which are available.

This can be tested with the following repository:
```
git clone git@github.com:Jubeki/laravel-sail-test-php82.git
cd laravel-sail-test-php82
cp .env.example .env
composer install --ignore-platform-reqs
sail up -d
sail composer update
sail artisan key:generate
sail php --version
open http://0.0.0.0
```