### PR TITLE
Add PHP 8.2 pcov extension again

### DIFF
--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -26,8 +26,7 @@ RUN apt-get update \
        php8.2-intl php8.2-readline \
        php8.2-ldap \
        php8.2-msgpack php8.2-igbinary php8.2-redis php8.2-swoole \
-       php8.2-memcached php8.2-xdebug \
-    #    php8.2-pcov \
+       php8.2-memcached php8.2-pcov php8.2-xdebug \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sLS https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \


### PR DESCRIPTION
PHP 8.2 pcov is now also available.
(I added it back to the same position as before)