### PR TITLE
Upgrade to Postgres 15

### DIFF
--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -1,5 +1,5 @@
     pgsql:
-        image: 'postgres:14'
+        image: 'postgres:15'
         ports:
             - '${FORWARD_DB_PORT:-5432}:5432'
         environment:


### PR DESCRIPTION
Postgres 15 was released on 13th October 2022:
https://www.postgresql.org/support/versioning/

Fixes #509 