### PR TITLE
Remove assumption that APP_URL=http://${APP_SERVICE}

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -306,7 +306,6 @@ elif [ "$1" == "dusk" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk "$@")
     else
@@ -320,7 +319,6 @@ elif [ "$1" == "dusk:fails" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
     else


### PR DESCRIPTION
As discussed in #521 I removed the forced `APP_URL=http://${APP_SERVICE}` in both `dusk` and `dusk:fails` command. 
