### PR TITLE
update devcontainer stub (vscode customizations)

### DIFF
--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -7,13 +7,17 @@
 	"service": "laravel.test",
 	"workspaceFolder": "/var/www/html",
 	"settings": {},
-	"extensions": [
-		// "mikestead.dotenv",
-		// "amiralizadeh9480.laravel-extra-intellisense",
-		// "ryannaddy.laravel-artisan",
-		// "onecentlin.laravel5-snippets",
-		// "onecentlin.laravel-blade"
-	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				// "mikestead.dotenv",
+				// "amiralizadeh9480.laravel-extra-intellisense",
+				// "ryannaddy.laravel-artisan",
+				// "onecentlin.laravel5-snippets",
+				// "onecentlin.laravel-blade"
+			]
+		}
+	},
 	"remoteUser": "sail",
 	"postCreateCommand": "chown -R 1000:1000 /var/www/html"
 	// "forwardPorts": [],


### PR DESCRIPTION
Based on vscode docs, in the devcontainer.json file, all the vscode extensions should be listed under customizations => vscode => extensions. 

https://code.visualstudio.com/docs/devcontainers/containers#_create-a-devcontainerjson-file
https://containers.dev/implementors/json_reference/

This MR adds the proper fields to the devcontainer.stub file so the generated devcontainer.json file will work properly in vscode containers.

There is no test required for this minor bug fix, but the generated devcontainer.json file will be in the proper format after this fix and if the user decides to uncomment a specific extension, it will be installed in the container without any issue.

Please let me know if I need to do any improvement to this MR, thanks.
