### PR TITLE
Fix: Alternative name for Apple Silicon machine

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -104,7 +104,7 @@ class InstallCommand extends Command
         $dockerCompose = str_replace('{{volumes}}', $volumes, $dockerCompose);
 
         // Replace Selenium with ARM base container on Apple Silicon...
-        if (in_array('selenium', $services) && php_uname('m') === 'arm64') {
+        if (in_array('selenium', $services) && in_array(php_uname('m'), ['arm64', 'aarch64'])) {
             $stubs = str_replace('selenium/standalone-chrome', 'seleniarm/standalone-chromium', $stubs);
         }
 


### PR DESCRIPTION
Fix for #529

If I do `sail artisan tinker`then and do `php_uname('m')` I get: `aarch64` 

[Wikipedia says](https://en.wikipedia.org/wiki/AArch64): AArch64 or ARM64 is the 64-bit extension of the ARM architecture family.

Thank you for your consideration.
