### PR TITLE
Add custom domain config to sail share

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -134,6 +134,7 @@ export SAIL_SHARE_DASHBOARD=${SAIL_SHARE_DASHBOARD:-4040}
 export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
 export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
+export SAIL_SHARE_DOMAIN=${SAIL_SHARE_DOMAIN:-""}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -472,6 +473,7 @@ elif [ "$1" == "share" ]; then
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
             --subdomain="$SAIL_SHARE_SUBDOMAIN" \
+            --domain="$SAIL_SHARE_DOMAIN" \
             "$@"
 
         exit


### PR DESCRIPTION
Currently it is possible to a number of Expose configuration values in your `.env` file that are passed through to Expose when running `sail share`.

However although custom subdomain support is included it is not possible to use a custom domain unless appending manually to your share command eg `sail share --domain=mydomain.com`.

This PR allows a custom domain to be set in your `.env` exactly the same as you auth token and other expose configuration items.