### PR TITLE
Use symfony/yaml, new Soketi service, and new sail:add command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "illuminate/console": "^8.0|^9.0|^10.0",
         "illuminate/contracts": "^8.0|^9.0|^10.0",
         "illuminate/support": "^8.0|^9.0|^10.0",
-        "symfony/yaml": "^6.2"
+        "symfony/yaml": "^6.0"
     },
     "bin": [
         "bin/sail"

--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,10 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
         "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0",
+        "illuminate/support": "^8.0|^9.0|^10.0",
+        "symfony/yaml": "^6.2"
     },
     "bin": [
         "bin/sail"

--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -3,38 +3,32 @@
 namespace Laravel\Sail\Console;
 
 use Illuminate\Console\Command;
-use RuntimeException;
-use Symfony\Component\Process\Process;
+use Laravel\Sail\Console\Concerns\InteractsWithDockerComposeServices;
 
-class InstallCommand extends Command
+class AddCommand extends Command
 {
-    use Concerns\InteractsWithDockerComposeServices;
+    use InteractsWithDockerComposeServices;
 
     /**
      * The name and signature of the console command.
      *
      * @var string
      */
-    protected $signature = 'sail:install
-                {--with= : The services that should be included in the installation}
-                {--devcontainer : Create a .devcontainer configuration directory}';
+    protected $signature = 'sail:add
+        {services? : The services that should be added to your setup.}
+    ';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Install Laravel Sail\'s default Docker Compose file';
+    protected $description = 'Add Laravel Sail\'s services to an existing sail install';
 
-    /**
-     * Execute the console command.
-     *
-     * @return int|null
-     */
     public function handle()
     {
-        if ($this->option('with')) {
-            $services = $this->option('with') == 'none' ? [] : explode(',', $this->option('with'));
+        if ($this->argument('services')) {
+            $services = $this->argument('services') == 'none' ? [] : explode(',', $this->argument('services'));
         } elseif ($this->option('no-interaction')) {
             $services = $this->defaultServices;
         } else {
@@ -51,11 +45,7 @@ class InstallCommand extends Command
         $this->replaceEnvVariables($services);
         $this->configurePhpUnit();
 
-        if ($this->option('devcontainer')) {
-            $this->installDevContainer();
-        }
-
-        $this->info('Sail scaffolding installed successfully.');
+        $this->info('Additional Sail services installed successfully.');
 
         $this->prepareInstallation($services);
     }

--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -23,7 +23,7 @@ class AddCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Add Laravel Sail\'s services to an existing sail install';
+    protected $description = 'Add Laravel Sail\'s services to an existing Sail install';
 
     /**
      * Execute the console command.

--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -15,7 +15,7 @@ class AddCommand extends Command
      * @var string
      */
     protected $signature = 'sail:add
-        {services? : The services that should be added to your setup.}
+        {services? : The services that should be added}
     ';
 
     /**
@@ -23,7 +23,7 @@ class AddCommand extends Command
      *
      * @var string
      */
-    protected $description = 'Add Laravel Sail\'s services to an existing Sail install';
+    protected $description = 'Add a service to an existing Sail installation';
 
     /**
      * Execute the console command.

--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -25,6 +25,11 @@ class AddCommand extends Command
      */
     protected $description = 'Add Laravel Sail\'s services to an existing sail install';
 
+    /**
+     * Execute the console command.
+     *
+     * @return int|null
+     */
     public function handle()
     {
         if ($this->argument('services')) {

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -38,7 +38,7 @@ trait InteractsWithDockerComposeServices
      */
     protected function gatherServicesWithSymfonyMenu()
     {
-        return $this->choice('Which services would you like to install?', $this->services, -1, null, true);
+        return $this->choice('Which services would you like to install?', $this->services, null, null, true);
     }
 
     /**

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -39,7 +39,7 @@ trait InteractsWithDockerComposeServices
      */
     protected function gatherServicesWithSymfonyMenu()
     {
-        return $this->choice('Which services would you like to install?', $this->services, null, null, true);
+        return $this->choice('Which services would you like to install?', $this->services, 0, null, true);
     }
 
     /**

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -60,7 +60,11 @@ trait InteractsWithDockerComposeServices
         if (! array_key_exists('laravel.test', $compose['services'])) {
             $this->warn('Couldn\'t find the laravel.test main service. Make sure you add [' . implode(',', $services) . '] to the depends_on config.');
         } else {
-            $compose['services']['laravel.test']['depends_on'] = array_values(array_unique(array_merge($compose['services']['laravel.test']['depends_on'] ?? [], $services)));
+            $compose['services']['laravel.test']['depends_on'] = collect($compose['services']['laravel.test']['depends_on'] ?? [])
+                ->merge($services)
+                ->unique()
+                ->values()
+                ->all();
         }
 
         // Add the services to the docker-compose.yml...

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace Laravel\Sail\Console\Concerns;
+
+use Symfony\Component\Process\Process;
+use Symfony\Component\Yaml\Yaml;
+
+trait InteractsWithDockerComposeServices
+{
+    /**
+     * The available services that may be installed.
+     *
+     * @var array<string>
+     */
+    protected $services = [
+        'mysql',
+        'pgsql',
+        'mariadb',
+        'redis',
+        'memcached',
+        'meilisearch',
+        'minio',
+        'mailpit',
+        'selenium',
+    ];
+
+    /**
+     * The default services used when the user chooses non-interactive mode.
+     *
+     * @var string[]
+     */
+    protected $defaultServices = ['mysql', 'redis', 'selenium', 'mailpit'];
+
+    /**
+     * Gather the desired Sail services using a Symfony menu.
+     *
+     * @return array
+     */
+    protected function gatherServicesWithSymfonyMenu()
+    {
+        return $this->choice('Which services would you like to install?', $this->services, -1, null, true);
+    }
+
+    /**
+     * Build the Docker Compose file.
+     *
+     * @param  array  $services
+     * @return void
+     */
+    protected function buildDockerCompose(array $services)
+    {
+        $composePath = base_path('docker-compose.yml');
+
+        $compose = file_exists($composePath)
+            ? Yaml::parseFile($composePath)
+            : Yaml::parse(file_get_contents(__DIR__ . '/../../../stubs/docker-compose.stub'));
+
+        // Merge the depends on service list...
+        $compose['services']['laravel.test']['depends_on'] = array_values(array_unique(array_merge($compose['services']['laravel.test']['depends_on'] ?? [], $services)));
+
+        // Add the services to the docker-compose.yml...
+        collect($services)
+            ->filter(function ($service) use ($compose) {
+                return ! array_key_exists($service, $compose['services'] ?? []);
+            })->each(function ($service) use (&$compose) {
+                $compose['services'][$service] = Yaml::parseFile(__DIR__ . "/../../../stubs/{$service}.stub")[$service];
+            });
+
+        // Merge volumes...
+        collect($services)
+            ->filter(function ($service) {
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
+            })->filter(function ($service) use ($compose) {
+                return ! array_key_exists($service, $compose['volumes'] ?? []);
+            })->each(function ($service) use (&$compose) {
+                $compose['volumes']["sail-{$service}"] = [
+                    'driver' => 'local',
+                ];
+            });
+
+        if (empty($compose['volumes'])) {
+            unset($compose['volumes']);
+        }
+
+        // Replace Selenium with ARM base container on Apple Silicon...
+        if (in_array('selenium', $services) && php_uname('m') === 'arm64') {
+            $compose['services']['selenium']['image'] = 'seleniarm/standalone-chromium';
+        }
+
+        file_put_contents($this->laravel->basePath('docker-compose.yml'), Yaml::dump($compose, Yaml::DUMP_OBJECT_AS_MAP));
+    }
+
+    /**
+     * Replace the Host environment variables in the app's .env file.
+     *
+     * @param  array  $services
+     * @return void
+     */
+    protected function replaceEnvVariables(array $services)
+    {
+        $environment = file_get_contents($this->laravel->basePath('.env'));
+
+        if (in_array('pgsql', $services)) {
+            $environment = str_replace('DB_CONNECTION=mysql', "DB_CONNECTION=pgsql", $environment);
+            $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=pgsql", $environment);
+            $environment = str_replace('DB_PORT=3306', "DB_PORT=5432", $environment);
+        } elseif (in_array('mariadb', $services)) {
+            $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mariadb", $environment);
+        } else {
+            $environment = str_replace('DB_HOST=127.0.0.1', "DB_HOST=mysql", $environment);
+        }
+
+        $environment = str_replace('DB_USERNAME=root', "DB_USERNAME=sail", $environment);
+        $environment = preg_replace("/DB_PASSWORD=(.*)/", "DB_PASSWORD=password", $environment);
+
+        $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
+        $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);
+
+        if (in_array('meilisearch', $services)) {
+            $environment .= "\nSCOUT_DRIVER=meilisearch";
+            $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
+        }
+
+        file_put_contents($this->laravel->basePath('.env'), $environment);
+    }
+
+    /**
+     * Configure PHPUnit to use the dedicated testing database.
+     *
+     * @return void
+     */
+    protected function configurePhpUnit()
+    {
+        if (! file_exists($path = $this->laravel->basePath('phpunit.xml'))) {
+            $path = $this->laravel->basePath('phpunit.xml.dist');
+        }
+
+        $phpunit = file_get_contents($path);
+
+        $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
+        $phpunit = str_replace('<!-- <env name="DB_DATABASE" value=":memory:"/> -->', '<env name="DB_DATABASE" value="testing"/>', $phpunit);
+
+        file_put_contents($this->laravel->basePath('phpunit.xml'), $phpunit);
+    }
+
+    /**
+     * Install the devcontainer.json configuration file.
+     *
+     * @return void
+     */
+    protected function installDevContainer()
+    {
+        if (! is_dir($this->laravel->basePath('.devcontainer'))) {
+            mkdir($this->laravel->basePath('.devcontainer'), 0755, true);
+        }
+
+        file_put_contents(
+            $this->laravel->basePath('.devcontainer/devcontainer.json'),
+            file_get_contents(__DIR__.'/../../stubs/devcontainer.stub')
+        );
+
+        $environment = file_get_contents($this->laravel->basePath('.env'));
+
+        $environment .= "\nWWWGROUP=1000";
+        $environment .= "\nWWWUSER=1000\n";
+
+        file_put_contents($this->laravel->basePath('.env'), $environment);
+    }
+
+    /**
+     * Prepare the installation by pulling and building any necessary images.
+     *
+     * @param  array  $services
+     * @return void
+     */
+    protected function prepareInstallation($services)
+    {
+        // Ensure docker is installed...
+        if ($this->runCommands(['docker info > /dev/null 2>&1']) !== 0) {
+            return;
+        }
+
+        if (count($services) > 0) {
+            $status = $this->runCommands([
+                './vendor/bin/sail pull '.implode(' ', $services),
+            ]);
+
+            if ($status === 0) {
+                $this->info('Sail images installed successfully.');
+            }
+        }
+
+        $status = $this->runCommands([
+            './vendor/bin/sail build',
+        ]);
+
+        if ($status === 0) {
+            $this->info('Sail build successful.');
+        }
+    }
+
+    /**
+     * Run the given commands.
+     *
+     * @param  array  $commands
+     * @return int
+     */
+    protected function runCommands($commands)
+    {
+        $process = Process::fromShellCommandline(implode(' && ', $commands), null, null, null, null);
+
+        if ('\\' !== DIRECTORY_SEPARATOR && file_exists('/dev/tty') && is_readable('/dev/tty')) {
+            try {
+                $process->setTty(true);
+            } catch (\RuntimeException $e) {
+                $this->output->writeln('  <bg=yellow;fg=black> WARN </> '.$e->getMessage().PHP_EOL);
+            }
+        }
+
+        return $process->run(function ($type, $line) {
+            $this->output->write('    '.$line);
+        });
+    }
+}

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -91,7 +91,7 @@ trait InteractsWithDockerComposeServices
         }
 
         // Replace Selenium with ARM base container on Apple Silicon...
-        if (in_array('selenium', $services) && php_uname('m') === 'arm64') {
+        if (in_array('selenium', $services) && in_array(php_uname('m'), ['arm64', 'aarch64'])) {
             $compose['services']['selenium']['image'] = 'seleniarm/standalone-chromium';
         }
 

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -22,6 +22,7 @@ trait InteractsWithDockerComposeServices
         'minio',
         'mailpit',
         'selenium',
+        'soketi',
     ];
 
     /**
@@ -122,6 +123,17 @@ trait InteractsWithDockerComposeServices
         if (in_array('meilisearch', $services)) {
             $environment .= "\nSCOUT_DRIVER=meilisearch";
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
+        }
+
+        if (in_array('soketi', $services)) {
+            $environment = preg_replace("/^BROADCAST_DRIVER=(.*)/m", "BROADCAST_DRIVER=pusher", $environment);
+            $environment = preg_replace("/^PUSHER_APP_ID=(.*)/m", "PUSHER_APP_ID=app-id", $environment);
+            $environment = preg_replace("/^PUSHER_APP_KEY=(.*)/m", "PUSHER_APP_KEY=app-key", $environment);
+            $environment = preg_replace("/^PUSHER_APP_SECRET=(.*)/m", "PUSHER_APP_SECRET=app-secret", $environment);
+            $environment = preg_replace("/^PUSHER_HOST=(.*)/m", "PUSHER_HOST=soketi", $environment);
+            $environment = preg_replace("/^PUSHER_PORT=(.*)/m", "PUSHER_PORT=6001", $environment);
+            $environment = preg_replace("/^PUSHER_SCHEME=(.*)/m", "PUSHER_SCHEME=http", $environment);
+            $environment = preg_replace("/^VITE_PUSHER_HOST=(.*)/m", "VITE_PUSHER_HOST=localhost", $environment);
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -121,8 +121,13 @@ trait InteractsWithDockerComposeServices
         $environment = str_replace('DB_USERNAME=root', "DB_USERNAME=sail", $environment);
         $environment = preg_replace("/DB_PASSWORD=(.*)/", "DB_PASSWORD=password", $environment);
 
-        $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
-        $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);
+        if (in_array('memcached', $services)) {
+            $environment = str_replace('MEMCACHED_HOST=127.0.0.1', 'MEMCACHED_HOST=memcached', $environment);
+        }
+
+        if (in_array('redis', $services)) {
+            $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=redis', $environment);
+        }
 
         if (in_array('meilisearch', $services)) {
             $environment .= "\nSCOUT_DRIVER=meilisearch";
@@ -138,6 +143,10 @@ trait InteractsWithDockerComposeServices
             $environment = preg_replace("/^PUSHER_PORT=(.*)/m", "PUSHER_PORT=6001", $environment);
             $environment = preg_replace("/^PUSHER_SCHEME=(.*)/m", "PUSHER_SCHEME=http", $environment);
             $environment = preg_replace("/^VITE_PUSHER_HOST=(.*)/m", "VITE_PUSHER_HOST=localhost", $environment);
+        }
+
+        if (in_array('mailpit', $services)) {
+            $environment = preg_replace("/^MAIL_HOST=(.*)/m", "MAIL_HOST=mailpit", $environment);
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -58,7 +58,7 @@ trait InteractsWithDockerComposeServices
 
         // Adds the new services as dependencies of the laravel.test service...
         if (! array_key_exists('laravel.test', $compose['services'])) {
-            $this->warn('Couldn\'t find the laravel.test main service. Make sure you add [' . implode(',', $services) . '] to the depends_on config.');
+            $this->warn('Couldn\'t find the laravel.test service. Make sure you add ['.implode(',', $services).'] to the depends_on config.');
         } else {
             $compose['services']['laravel.test']['depends_on'] = collect($compose['services']['laravel.test']['depends_on'] ?? [])
                 ->merge($services)
@@ -85,7 +85,7 @@ trait InteractsWithDockerComposeServices
                 $compose['volumes']["sail-{$service}"] = ['driver' => 'local'];
             });
 
-        // If the volumes is empty, we can remove it...
+        // If the list of volumes is empty, we can remove it...
         if (empty($compose['volumes'])) {
             unset($compose['volumes']);
         }

--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -4,6 +4,7 @@ namespace Laravel\Sail;
 
 use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\ServiceProvider;
+use Laravel\Sail\Console\AddCommand;
 use Laravel\Sail\Console\InstallCommand;
 use Laravel\Sail\Console\PublishCommand;
 
@@ -30,6 +31,7 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 InstallCommand::class,
+                AddCommand::class,
                 PublishCommand::class,
             ]);
         }

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -22,9 +22,6 @@ services:
             - '.:/var/www/html'
         networks:
             - sail
-{{depends}}
-{{services}}
 networks:
     sail:
         driver: bridge
-{{volumes}}

--- a/stubs/mailpit.stub
+++ b/stubs/mailpit.stub
@@ -1,7 +1,7 @@
-    mailpit:
-        image: 'axllent/mailpit:latest'
-        ports:
-            - '${FORWARD_MAILPIT_PORT:-1025}:1025'
-            - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
-        networks:
-            - sail
+mailpit:
+    image: 'axllent/mailpit:latest'
+    ports:
+        - '${FORWARD_MAILPIT_PORT:-1025}:1025'
+        - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+    networks:
+        - sail

--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -1,20 +1,20 @@
-    mariadb:
-        image: 'mariadb:10'
-        ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
-        environment:
-            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ROOT_HOST: "%"
-            MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
-        volumes:
-            - 'sail-mariadb:/var/lib/mysql'
-            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
-        networks:
-            - sail
-        healthcheck:
-            test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
-            retries: 3
-            timeout: 5s
+mariadb:
+    image: 'mariadb:10'
+    ports:
+        - '${FORWARD_DB_PORT:-3306}:3306'
+    environment:
+        MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+        MYSQL_ROOT_HOST: "%"
+        MYSQL_DATABASE: '${DB_DATABASE}'
+        MYSQL_USER: '${DB_USERNAME}'
+        MYSQL_PASSWORD: '${DB_PASSWORD}'
+        MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
+    volumes:
+        - 'sail-mariadb:/var/lib/mysql'
+        - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+        retries: 3
+        timeout: 5s

--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -1,12 +1,12 @@
-    meilisearch:
-        image: 'getmeili/meilisearch:latest'
-        ports:
-            - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
-        volumes:
-            - 'sail-meilisearch:/meili_data'
-        networks:
-            - sail
-        healthcheck:
-            test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
-            retries: 3
-            timeout: 5s
+meilisearch:
+    image: 'getmeili/meilisearch:latest'
+    ports:
+        - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+    volumes:
+        - 'sail-meilisearch:/meili_data'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
+        retries: 3
+        timeout: 5s

--- a/stubs/memcached.stub
+++ b/stubs/memcached.stub
@@ -1,6 +1,6 @@
-    memcached:
-        image: 'memcached:alpine'
-        ports:
-            - '${FORWARD_MEMCACHED_PORT:-11211}:11211'
-        networks:
-            - sail
+memcached:
+    image: 'memcached:alpine'
+    ports:
+        - '${FORWARD_MEMCACHED_PORT:-11211}:11211'
+    networks:
+        - sail

--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -1,17 +1,17 @@
-    minio:
-        image: 'minio/minio:latest'
-        ports:
-            - '${FORWARD_MINIO_PORT:-9000}:9000'
-            - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
-        environment:
-            MINIO_ROOT_USER: 'sail'
-            MINIO_ROOT_PASSWORD: 'password'
-        volumes:
-            - 'sail-minio:/data/minio'
-        networks:
-            - sail
-        command: minio server /data/minio --console-address ":8900"
-        healthcheck:
-            test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-            retries: 3
-            timeout: 5s
+minio:
+    image: 'minio/minio:latest'
+    ports:
+        - '${FORWARD_MINIO_PORT:-9000}:9000'
+        - '${FORWARD_MINIO_CONSOLE_PORT:-8900}:8900'
+    environment:
+        MINIO_ROOT_USER: 'sail'
+        MINIO_ROOT_PASSWORD: 'password'
+    volumes:
+        - 'sail-minio:/data/minio'
+    networks:
+        - sail
+    command: minio server /data/minio --console-address ":8900"
+    healthcheck:
+        test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+        retries: 3
+        timeout: 5s

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -1,20 +1,20 @@
-    mysql:
-        image: 'mysql/mysql-server:8.0'
-        ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
-        environment:
-            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ROOT_HOST: "%"
-            MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        volumes:
-            - 'sail-mysql:/var/lib/mysql'
-            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
-        networks:
-            - sail
-        healthcheck:
-            test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
-            retries: 3
-            timeout: 5s
+mysql:
+    image: 'mysql/mysql-server:8.0'
+    ports:
+        - '${FORWARD_DB_PORT:-3306}:3306'
+    environment:
+        MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+        MYSQL_ROOT_HOST: "%"
+        MYSQL_DATABASE: '${DB_DATABASE}'
+        MYSQL_USER: '${DB_USERNAME}'
+        MYSQL_PASSWORD: '${DB_PASSWORD}'
+        MYSQL_ALLOW_EMPTY_PASSWORD: 1
+    volumes:
+        - 'sail-mysql:/var/lib/mysql'
+        - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
+        retries: 3
+        timeout: 5s

--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -1,18 +1,18 @@
-    pgsql:
-        image: 'postgres:15'
-        ports:
-            - '${FORWARD_DB_PORT:-5432}:5432'
-        environment:
-            PGPASSWORD: '${DB_PASSWORD:-secret}'
-            POSTGRES_DB: '${DB_DATABASE}'
-            POSTGRES_USER: '${DB_USERNAME}'
-            POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
-        volumes:
-            - 'sail-pgsql:/var/lib/postgresql/data'
-            - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
-        networks:
-            - sail
-        healthcheck:
-            test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
-            retries: 3
-            timeout: 5s
+pgsql:
+    image: 'postgres:15'
+    ports:
+        - '${FORWARD_DB_PORT:-5432}:5432'
+    environment:
+        PGPASSWORD: '${DB_PASSWORD:-secret}'
+        POSTGRES_DB: '${DB_DATABASE}'
+        POSTGRES_USER: '${DB_USERNAME}'
+        POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
+    volumes:
+        - 'sail-pgsql:/var/lib/postgresql/data'
+        - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "pg_isready", "-q", "-d", "${DB_DATABASE}", "-U", "${DB_USERNAME}"]
+        retries: 3
+        timeout: 5s

--- a/stubs/redis.stub
+++ b/stubs/redis.stub
@@ -1,12 +1,12 @@
-    redis:
-        image: 'redis:alpine'
-        ports:
-            - '${FORWARD_REDIS_PORT:-6379}:6379'
-        volumes:
-            - 'sail-redis:/data'
-        networks:
-            - sail
-        healthcheck:
-            test: ["CMD", "redis-cli", "ping"]
-            retries: 3
-            timeout: 5s
+redis:
+    image: 'redis:alpine'
+    ports:
+        - '${FORWARD_REDIS_PORT:-6379}:6379'
+    volumes:
+        - 'sail-redis:/data'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "redis-cli", "ping"]
+        retries: 3
+        timeout: 5s

--- a/stubs/selenium.stub
+++ b/stubs/selenium.stub
@@ -1,8 +1,8 @@
-    selenium:
-        image: 'selenium/standalone-chrome'
-        extra_hosts:
-            - 'host.docker.internal:host-gateway'
-        volumes:
-            - '/dev/shm:/dev/shm'
-        networks:
-            - sail
+selenium:
+    image: 'selenium/standalone-chrome'
+    extra_hosts:
+        - 'host.docker.internal:host-gateway'
+    volumes:
+        - '/dev/shm:/dev/shm'
+    networks:
+        - sail

--- a/stubs/soketi.stub
+++ b/stubs/soketi.stub
@@ -1,0 +1,13 @@
+soketi:
+    image: 'quay.io/soketi/soketi:latest-16-alpine'
+    environment:
+        SOKETI_DEBUG: '${SOKETI_DEBUG:-1}'
+        SOKETI_METRICS_SERVER_PORT: '9601'
+        SOKETI_DEFAULT_APP_ID: '${PUSHER_APP_ID}'
+        SOKETI_DEFAULT_APP_KEY: '${PUSHER_APP_KEY}'
+        SOKETI_DEFAULT_APP_SECRET: '${PUSHER_APP_SECRET}'
+    ports:
+        - '${PUSHER_PORT:-6001}:6001'
+        - '${PUSHER_METRICS_PORT:-9601}:9601'
+    networks:
+        - sail


### PR DESCRIPTION
### Changed

- Adds the `symfony/yaml` dependency to ease Yaml manipulation (there are some differences to the generated Yaml file, I'll try to describe them below)
- Extracted some of the `InstallCommand` methods into a `InteractsWithDockerComposeServices` concern (trait). I needed those methods in the new `sail:add` command.

### Add

- Adds a new `artisan sail:add` command that we can use to add new services to our Sail setup. We're currently expecting this command to run from the host machine (since it uses some docker commands in the `prepareInstallation` method). I _think_ the `sail:install` command also has the same expectation (I've always ran it from my host machine)
- Adds a new `soketi` service to ease broadcasting setup on Sail

---

There are some changes to the Yaml generated by the `symfony/yaml` package, especially around sequences. One example is the Redis health-check command:

Before:

```yml
services:
    # ...
    redis:
        # ...
        healthcheck:
            test: ["CMD", "redis-cli", "ping"]
```

After:

```yml
services:
    # ...
    redis:
        # ...
        healthcheck:
            test:
                - CMD
                - redis-cli
                - ping
```

Both versions work the same, I guess it's just aesthetics (I prefer the before). Couldn't find a way to change it (maybe we could do some string manipulation as before?)

I explored adding a `sail add` command to the `bin/sail` script, but not sure. The script would need a few changes, 'cause we can run `php artisan sail:add` inside the container but we'd need to run the docker commands from the host machine (unless we share the docker socket with the container and install docker in the `laravel.test`, this way I believe we could run the `prepareInstallation` method inside the container as well).

**Why not use the `artisan sail:install` to add the new dependencies?**

That's what I've been using. But I always had to list all services I wanted to keep + the new service. Even though the new `sail:add` command and the `sail:install` command are technically the same now (after the changes here), the add one passes the intention of addition. But I guess it's not necessary.

---

This is all a proof of concept. Wasn't sure where to suggest the `sail:add` feature, but the GH workflow said to open a PR. Happy to open separate PRs in case y'all don't want to add an extra dependency, or don't want to add soketi, etc.