### PR TITLE
#481 Fixed sail up and added code for WWWGROUP=1000 addition in .env file

### DIFF
--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -28,8 +28,11 @@ RUN apt-get update \
        php8.2-msgpack php8.2-igbinary php8.2-redis php8.2-swoole \
        php8.2-memcached php8.2-pcov php8.2-xdebug \
     && php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
-    && curl -sLS https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
-    && apt-get install -y nodejs \
+    && curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.0/install.sh -o install_nvm.sh | bash - \
+    && bash install_nvm.sh \
+    && export NVM_DIR="$HOME/.nvm" \
+    && [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" \
+    && nvm install --lts \
     && npm install -g npm \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -161,6 +161,11 @@ class InstallCommand extends Command
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
         }
 
+        if (!preg_match("/WWWGROUP=1000/", $environment)) {
+            $environment .= "\nWWWGROUP=1000";
+            $environment .= "\nWWWUSER=1000\n";
+        }
+
         file_put_contents($this->laravel->basePath('.env'), $environment);
     }
 


### PR DESCRIPTION
@driesvints Because of the nature of [this issue](https://github.com/laravel/sail/issues/481) I am raising this PR to bring your attention. I find this issue happening only with new people trying to setup and run sail in their newly configured system, once I got it working the Issue never came back, because of this nature this issue might be steering new people away from trying or using sail the first time and after the issue, they will just give up.

 I faced two issues in total as follows:

1. npm: not found
which I solved by doing some modifications to the Docker file

2.  Permission denied The exception occurred while attempting to log : The stream or file "/var/www/html/storage/logs/laravel.log" 
which I googled and found the solution to add 
`WWWGROUP=1000 
WWWUSER=1000`
in the .env file.

This first issue is very weird since after I solved it, my container image was generated and sail started working fine, even after deleting everything from docker and re-installing I didn't faced the first issue.
I even uninstalled docker and re-installed it but wasn't able to reproduce it, seems to be happening very rarely when certain conditions meet.
My ubuntu version is 22 and I didn't specify any version in the `sail up -d` command so it was using 8.2 runtimes.

I have applied the fix and raised this PR so you can have a look and come up with some solution, Please feel free to close this PR, In that case, I will write a blog and post into that issue discussion so if someone will face the issue again in future they will have some solution to look into. 

