### PR TITLE
Fixed the path to devcontainer.stub

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -184,7 +184,7 @@ trait InteractsWithDockerComposeServices
 
         file_put_contents(
             $this->laravel->basePath('.devcontainer/devcontainer.json'),
-            file_get_contents(__DIR__.'/../../stubs/devcontainer.stub')
+            file_get_contents(__DIR__.'/../../../stubs/devcontainer.stub')
         );
 
         $environment = file_get_contents($this->laravel->basePath('.env'));


### PR DESCRIPTION
The wrong path was being used to copy the  content of `devcontainer.stub` file to `.devcontainer/devcontainer.json `. Trowing the following error: `file_get_contents(/opt/{Project folder}/vendor/laravel/sail/src/Console/Concerns/../../stubs/devcontainer.stub): Failed to open stream: No such file or directory`.
