### PR TITLE
Persist emails in mailpit

### DIFF
--- a/stubs/mailpit.stub
+++ b/stubs/mailpit.stub
@@ -3,5 +3,7 @@ mailpit:
     ports:
         - '${FORWARD_MAILPIT_PORT:-1025}:1025'
         - '${FORWARD_MAILPIT_DASHBOARD_PORT:-8025}:8025'
+    environment:
+        MP_DATA_FILE: '/var/mailpit.db'
     networks:
         - sail


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->

Add configuratión to persist emails in Mailpit, with this the user dont lose yout test emails when reset docker.