### PR TITLE
Added Imagick to the php runtimes

### DIFF
--- a/runtimes/7.4/Dockerfile
+++ b/runtimes/7.4/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu focal main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
     && apt-get install -y php7.4-cli php7.4-dev \
-       php7.4-pgsql php7.4-sqlite3 php7.4-gd \
+       php7.4-pgsql php7.4-sqlite3 php7.4-gd php7.4-imagick \
        php7.4-curl php7.4-memcached \
        php7.4-imap php7.4-mysql php7.4-mbstring \
        php7.4-xml php7.4-zip php7.4-bcmath php7.4-soap \

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu focal main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
     && apt-get install -y php8.0-cli php8.0-dev \
-       php8.0-pgsql php8.0-sqlite3 php8.0-gd \
+       php8.0-pgsql php8.0-sqlite3 php8.0-gd php8.0-imagick \
        php8.0-curl php8.0-memcached \
        php8.0-imap php8.0-mysql php8.0-mbstring \
        php8.0-xml php8.0-zip php8.0-bcmath php8.0-soap \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
     && apt-get install -y php8.1-cli php8.1-dev \
-       php8.1-pgsql php8.1-sqlite3 php8.1-gd \
+       php8.1-pgsql php8.1-sqlite3 php8.1-gd php8.1-imagick \
        php8.1-curl \
        php8.1-imap php8.1-mysql php8.1-mbstring \
        php8.1-xml php8.1-zip php8.1-bcmath php8.1-soap \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
     && apt-get install -y php8.2-cli php8.2-dev \
-       php8.2-pgsql php8.2-sqlite3 php8.2-gd \
+       php8.2-pgsql php8.2-sqlite3 php8.2-gd php8.2-imagick \
        php8.2-curl \
        php8.2-imap php8.2-mysql php8.2-mbstring \
        php8.2-xml php8.2-zip php8.2-bcmath php8.2-soap \


### PR DESCRIPTION
I am suggesting adding phpx.x-imagick to the dockerfile for each runtime. The reason this would help others is Imagick is quite common in its use when it comes to using Intervention, Spatie packages as well as general image manipulation. This would save a lot of time and stress for people having to customize their dockerfile. By preventing one-off customizations a lot of issues will be alleviated from various issue reports. 

I did test this on each runtime and there are no errors or deployment issues. 