### PR TITLE
Suggest copying .env.example to .env and generating key:generate before launch

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -145,6 +145,11 @@ elif [ -f ./.env ]; then
   source ./.env;
 fi
 
+if [ "$1" != "artisan" ] && [ "$APP_NAME" != "" ] && [ "$APP_KEY" = "" ]; then
+    echo "${BOLD}${YELLOW}Your application does not have any application key."
+    echo "You may generate by using the following command: './vendor/bin/sail key:generate'${NC}"
+fi
+
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}

--- a/bin/sail
+++ b/bin/sail
@@ -108,6 +108,20 @@ function display_help {
     exit 1
 }
 
+function confirm_yes_no() {
+    echo -n "${BOLD}$1 [Y/n]: ${NC}"
+    read -r ANSWER
+
+    case $ANSWER in
+    "" | [Yy]*)
+        return 0
+    ;;
+    *)
+        return 1
+    ;;
+    esac
+}
+
 # Proxy the "help" command...
 if [ $# -gt 0 ]; then
     if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
@@ -115,6 +129,13 @@ if [ $# -gt 0 ]; then
     fi
 else
     display_help
+fi
+
+if [ -f ./.env.example ] && [ ! -f ./env ]; then
+    if confirm_yes_no ".env does not exist and .env.example exists. Would you like to copy .env.example to .env?"; then
+        cp ./.env.example ./.env
+        echo "Successfully copied .env.example to .env."
+    fi
 fi
 
 # Source the ".env" file so Laravel's environment variables are available...


### PR DESCRIPTION
Launching a Laravel project generally requires APP_KEY is filled (by using `artisan key:generate` usually) and .env.example is copied to .env.

This pull request proposes to add suggestion for these requirements before launching using `./vendor/bin/sail up` or `up -d` commands. Since `./vendor/bin/sail artisan key:generate` requires the project is already up, so Sail only warns about APP_KEY is empty, not able to generate automatically as same as .env.