### PR TITLE
Enable Expose Global Server Infrastructure

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -137,6 +137,7 @@ export SAIL_SHARE_SERVER_HOST=${SAIL_SHARE_SERVER_HOST:-"laravel-sail.site"}
 export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
 export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
 export SAIL_SHARE_DOMAIN=${SAIL_SHARE_DOMAIN:-"$SAIL_SHARE_SERVER_HOST"}
+export SAIL_SHARE_SERVER=${SAIL_SHARE_SERVER:-""}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -486,6 +487,7 @@ elif [ "$1" == "share" ]; then
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
+            --server="$SAIL_SHARE_SERVER" \
             --subdomain="$SAIL_SHARE_SUBDOMAIN" \
             --domain="$SAIL_SHARE_DOMAIN" \
             "$@"


### PR DESCRIPTION
`expose` provides the `--server` option to allow users to select servers closer to their geographic location. 

[Expose - Global Server Infrastructure](https://expose.dev/docs/client/global-server-infrastructure)

Adding this environment variable would allow customization of that parameter for interested users.

If, for some reason, this PR isn't accepted, I'll leave a workaround here:

```
SAIL_SHARE_SERVER_HOST=eu-1.sharedwithexpose.com
```

Setting this env var effectively does the same thing.