### PR TITLE
Bugfix Meilisearch

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -3,7 +3,7 @@ meilisearch:
     ports:
         - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
     volumes:
-        - 'sail-meilisearch:/meili_data'
+        - 'sail-meilisearch:/data.ms'
     networks:
         - sail
     healthcheck:


### PR DESCRIPTION
PR to this Issue: [ISSUE](https://github.com/laravel/sail/issues/567)

This PR fix a bug in meilisearch volume. If we create a new laravel project with laravel sail, e run the `sail up` in project, the message error view in logs, picture here:

![Screenshot from 2023-03-25 09-34-53](https://user-images.githubusercontent.com/45684782/227724246-9d0ff1cb-3ce0-4cc4-900a-1f77a5d5eed7.png)