### PR TITLE
[1.x] Speeds up CLI and tests by enabling OpCache

### DIFF
--- a/runtimes/7.4/php.ini
+++ b/runtimes/7.4/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1

--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1

--- a/runtimes/8.2/php.ini
+++ b/runtimes/8.2/php.ini
@@ -2,3 +2,6 @@
 post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
+
+[opcache]
+opcache.enable_cli=1


### PR DESCRIPTION
Hi all,

So I've been toying around with eeking out further performance when running tests. I notice that in Sail, OpCache is enabled with `validate_timestamps` set to 1 and `revalidate_freq` set to 0 so that changes are applied immediately. However, `enable_cli` is disabled (as is the default for OpCache). 

By enabling this flag, we can significantly improve the time is takes to execute tests inside Sail. On a project running L10, Pest v2 with parallel enabled, I was able to reduce the time to run the test suite from 51s to 42s, ~20% improvement. No other changes were made.

Thanks as always for all the hard work.

Kind Regards,
Luke