### PR TITLE
check if --dirty flag is passed for pint and pass files changed as argument for pint

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -108,6 +108,42 @@ function display_help {
     exit 1
 }
 
+# Function to return the files changed listed from command "git status --short -- '**.php'"
+function get_files_changed {
+    # Run `git status --short` and save the output to a variable
+    GIT_STATUS=$(git status --short -- '**.php')
+
+    # Track the files that are changed
+    FILES_FROM_GIT_STATUS=()
+
+    # Loop over the files changed
+    while read -r line; do
+    STATUS="${line:0:2}"
+    FILE="${line:2}"
+
+    STATUS="${STATUS#"${STATUS%%[![:space:]]*}"}" # remove leading whitespace
+    STATUS="${STATUS%"${STATUS##*[![:space:]]}"}" # remove trailing whitespace
+    FILE="${FILE#"${FILE%%[![:space:]]*}"}" # remove leading whitespace
+    FILE="${FILE%"${FILE##*[![:space:]]}"}" # remove trailing whitespace
+
+    # If the STATUS is "??", set the STATUS to "N"
+    if [ "$STATUS" = "??" ]; then
+        STATUS="N"
+    fi
+
+    if [ "$STATUS" != "D" ]; then
+        if [ "$STATUS" = "R" ]; then
+        # If the STATUS is "R", extract the new FILE name
+        FILE=${FILE#* -> }
+        fi
+
+        FILES_FROM_GIT_STATUS+=($FILE)
+    fi
+    done <<< "$GIT_STATUS"
+
+    echo "${FILES_FROM_GIT_STATUS[@]}"
+}
+
 # Proxy the "help" command...
 if [ $# -gt 0 ]; then
     if [ "$1" == "help" ] || [ "$1" == "-h" ] || [ "$1" == "-help" ] || [ "$1" == "--help" ]; then
@@ -310,7 +346,26 @@ elif [ "$1" == "pint" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/pint "$@")
+
+        HAS_DIRTY=false
+
+        for arg in "$@"
+        do
+            # Check if the argument is equal to the desired value
+            if [ "$arg" = "--dirty" ]; then
+                HAS_DIRTY=true
+                break
+            fi
+        done
+
+        if $HAS_DIRTY; then
+            FILES_FROM_GIT_STATUS=$(get_files_changed)
+
+            ARGS+=("$APP_SERVICE" php vendor/bin/pint $FILES_FROM_GIT_STATUS)
+        else
+            ARGS+=("$APP_SERVICE" php vendor/bin/pint "$@")
+        fi
+
     else
         sail_is_not_running
     fi

--- a/bin/sail
+++ b/bin/sail
@@ -137,7 +137,7 @@ function get_files_changed {
         FILE=${FILE#* -> }
         fi
 
-        FILES_FROM_GIT_STATUS+=($FILE)
+        FILES_FROM_GIT_STATUS+=("${FILE}")
     fi
     done <<< "$GIT_STATUS"
 
@@ -359,9 +359,9 @@ elif [ "$1" == "pint" ]; then
         done
 
         if $HAS_DIRTY; then
-            FILES_FROM_GIT_STATUS=$(get_files_changed)
+            read -r -a FILES_CHANGED <<< "$(get_files_changed)"
 
-            ARGS+=("$APP_SERVICE" php vendor/bin/pint $FILES_FROM_GIT_STATUS)
+            ARGS+=("$APP_SERVICE" php vendor/bin/pint "${FILES_CHANGED[@]}")
         else
             ARGS+=("$APP_SERVICE" php vendor/bin/pint "$@")
         fi


### PR DESCRIPTION
This PR relates to https://github.com/laravel/pint/issues/169

Currently, when running pint from sail with `--dirty` flag, the pint doesn't work as the container is not a git repo.

In this PR, I have checked if the `--dirty` argument is passed and if it's passed, the list of files changed will be passed as an argument to pint rather. 

**Without the flag `--dirty` it works without any change.** 
<img width="638" alt="image" src="https://user-images.githubusercontent.com/26411488/231379093-0919b9b6-5464-4adc-af52-7d7f26fb8946.png">

**With the flag `--dirty` it will update the files only those that are modified.** 
<img width="578" alt="image" src="https://user-images.githubusercontent.com/26411488/231379204-4ebb2c47-d5c7-4aec-b123-ebfaa5ce8a66.png">

**These are the files changed shown by `git status --short -- '**.php'`**
<img width="291" alt="image" src="https://user-images.githubusercontent.com/26411488/231379409-05e664ea-1b89-492f-a66d-9637830720d2.png">

**In the previous script, passing `--dirty` flag make no changes in the files**
<img width="907" alt="image" src="https://user-images.githubusercontent.com/26411488/231379813-81602ed7-282b-4da3-a6a8-33b795b7914b.png">


## NOTE ⚠️ 

The [excluding files](https://laravel.com/docs/10.x/pint#excluding-files-or-folders) config of `pint.json` will not be respected for now because pint ignores these configs when a file path argument is passed.
 