### PR TITLE
Add schedule:work as crontab alternative

### DIFF
--- a/runtimes/7.4/supervisord.conf
+++ b/runtimes/7.4/supervisord.conf
@@ -8,6 +8,17 @@ pidfile=/var/run/supervisord.pid
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
+priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:schedule]
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan schedule:work
+user=sail
+environment=LARAVEL_SAIL="1"
+priority=200
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -8,6 +8,17 @@ pidfile=/var/run/supervisord.pid
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
+priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:schedule]
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan schedule:work
+user=sail
+environment=LARAVEL_SAIL="1"
+priority=200
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -8,6 +8,17 @@ pidfile=/var/run/supervisord.pid
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
+priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:schedule]
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan schedule:work
+user=sail
+environment=LARAVEL_SAIL="1"
+priority=200
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -8,6 +8,17 @@ pidfile=/var/run/supervisord.pid
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail
 environment=LARAVEL_SAIL="1"
+priority=100
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:schedule]
+command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan schedule:work
+user=sail
+environment=LARAVEL_SAIL="1"
+priority=200
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr


### PR DESCRIPTION
I think this would be a good addition. The scheduler can be run using a single command and without a cronjob.
I have also added `priority`, as the `php-fpm` should be, in most cases, the one started first and stopped last.

Let me know your thoughts, if this should be in the docs instead, I'm happy to do this as well. :)

Thanks.