### PR TITLE
Fix opening files from Ignition error page

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -18,6 +18,7 @@ services:
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'
+            IGNITION_LOCAL_SITES_PATH: '${PWD}'
         volumes:
             - '.:/var/www/html'
         networks:


### PR DESCRIPTION
The Ignition error page has a feature where you can open the file where an error occurred in your preferred IDE, simply by clicking on a link. However, as you can see in my demonstration video below, this feature does not work out of the box when using Docker (at least with Sail's current setup), since Ignition does not know where the project resides on the host machine and generates links to `/var/www/html`:

https://user-images.githubusercontent.com/10284694/233837874-e1b69fde-134f-451c-9d67-a2c32eec2599.mov


To support this scenario, Ignition allows you to define the `IGNITION_LOCAL_SITES_PATH` environment variable ([docs](https://flareapp.io/docs/ignition-for-laravel/configuration#remote-development-server-support)), which you can use to configure the path to the project on the host machine, thereby fixing the link generation.

This PR sets `IGNITION_LOCAL_SITES_PATH` to the current working directory based on the `PWD` environment variable in the `docker-compose.yml`. This way Ignition's link generation just works when using Sail.

## Caveats

Relying on the `PWD` environment variable is not perfect.
You _could_ start your compose services from outside the project directory, by e.g. running `example-app/vendor/bin/sail -f example-app/docker-compose.yml up`. In this case, wrong links are generated, but I think supporting this edge case is not worth the effort.

Since this PR passes `IGNITION_LOCAL_SITES_PATH` as a _real_ system envirnoment variable and not through a`.env` file, it does not automatically get passed to the PHP server process by the `ServeCommand`. Therefore this PR depends upon https://github.com/laravel/framework/pull/46857 to work properly, which adds `IGNITION_LOCAL_SITES_PATH` to the list of environment variables passed to PHP by default.

I tested the fix on Linux and MacOS and can confirm that it works. I don't have access to a computer running Windows, and don't know if this fix works in WSL.

## Reproduction Steps

```
curl -s "https://laravel.build/example-app" | bash
```

follow the installation instructions

```
cd example-app && vendor/bin/sail up
```

change the contents of `routes/web.php` to throw an exception

```php
Route::get('/', function () {
    throw new \Exception("Whoops!");

    return view('welcome');
});
```

and visit http://localhost in the browser.
You should now be able to reproduce the behavior shown in the screen recording.

Then adjust the contents of `docker-compose.yml` to those of this PR and restart Sail.
Also make sure to apply the changes of https://github.com/laravel/framework/pull/46857 to the `ServeCommand` in your `vendor/` folder.

Opening files by clicking on the link should work again now:

https://user-images.githubusercontent.com/10284694/233837952-2b8e066f-7b03-4245-b87d-b1e0b9e4bf77.mov
