### PR TITLE
Add npm run dev to supervisord

### DIFF
--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:npm]
+command=/usr/bin/npm run --prefix /var/www/html dev
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:npm]
+command=/usr/bin/npm run --prefix /var/www/html dev
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:npm]
+command=/usr/bin/npm run --prefix /var/www/html dev
+user=sail
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
The first thing I do after running my alias for `./vendor/bin/sail up -d` when working on a project is open up a second terminal window and run my alias for `./vendor/bin/sail npm run dev` to start the Vite watcher.

It occurred to me I don't have to manually run `./vendor/bin/sail artisan serve`, sail does that automatically in the background, why not do the same for `npm run dev`? Its just a small supervisord config, so this PR does just that making one less step to get up and running in development.

NOTE: Existing projects using sail would have to run `./vendor/bin/sail build` to get the update supervisord.conf in their container image.