### PR TITLE
An alternate environment file so Docker compose

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -171,6 +171,13 @@ if [ -n "$SAIL_FILES" ]; then
     done
 fi
 
+# An alternate environment file so Docker compose environment variables are available...
+if [ ! -z "$APP_ENV" ] && [ -f ./.env.$APP_ENV ]; then
+ DOCKER_COMPOSE+=(--env-file ".env.$APP_ENV")
+elif [ -f ./.env ]; then
+ DOCKER_COMPOSE+=(--env-file ".env")
+fi
+
 EXEC="yes"
 
 if [ -z "$SAIL_SKIP_CHECKS" ]; then


### PR DESCRIPTION
Hello,

I had an issue when working with a container through Sail, where the variables from .env.local were not being passed, even though the variable "APP_ENV=local" was set.

I received the following warning message: "WARN[0000] The "VAR_NAME" variable is not set. Defaulting to a blank string."

I may have been using "./vendor/bin/sail" incorrectly. Here's my "sail" file located in the root directory of my project:

#!/usr/bin/env bash

export APP_ENV=local
./vendor/bin/sail "$@"


This fix resolves the issue.

Perhaps there is another solution that doesn't involve modifying the library. I would appreciate it if you could share any alternative solutions.