### PR TITLE
add `a` as alias for artisan command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -244,7 +244,7 @@ elif [ "$1" == "composer" ]; then
     fi
 
 # Proxy Artisan commands to the "artisan" binary on the application container...
-elif [ "$1" == "artisan" ] || [ "$1" == "art" ]; then
+elif [ "$1" == "artisan" ] || [ "$1" == "art" ] || [ "$1" == "a" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then


### PR DESCRIPTION
Nothing out of the ordinary, juste a smaller alias since many devs who use Laravel without sail already use `a` for artisan for quite some time now.