### PR TITLE
Also publish database init scripts

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -28,6 +28,7 @@ class PublishCommand extends Command
     public function handle()
     {
         $this->call('vendor:publish', ['--tag' => 'sail-docker']);
+        $this->call('vendor:publish', ['--tag' => 'sail-database']);
 
         file_put_contents(
             $this->laravel->basePath('docker-compose.yml'),
@@ -36,11 +37,15 @@ class PublishCommand extends Command
                     './vendor/laravel/sail/runtimes/8.2',
                     './vendor/laravel/sail/runtimes/8.1',
                     './vendor/laravel/sail/runtimes/8.0',
+                    './vendor/laravel/sail/database/mysql',
+                    './vendor/laravel/sail/database/pgsql'
                 ],
                 [
                     './docker/8.2',
                     './docker/8.1',
                     './docker/8.0',
+                    './docker/mysql',
+                    './docker/pgsql'
                 ],
                 file_get_contents($this->laravel->basePath('docker-compose.yml'))
             )

--- a/src/SailServiceProvider.php
+++ b/src/SailServiceProvider.php
@@ -52,6 +52,10 @@ class SailServiceProvider extends ServiceProvider implements DeferrableProvider
             $this->publishes([
                 __DIR__ . '/../bin/sail' => $this->app->basePath('sail'),
             ], ['sail', 'sail-bin']);
+
+            $this->publishes([
+                __DIR__ . '/../database' => $this->app->basePath('docker'),
+            ], ['sail', 'sail-database']);
         }
     }
 


### PR DESCRIPTION
Publish the testing database init scripts so containers can be build more comfortable even without vendor dir present.

Useful for example when using an existing app or use a Dev Container for the php commands. 

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
