### PR TITLE
Upgrade the Compose file format version to Compose specification

### DIFF
--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -1,5 +1,4 @@
 # For more information: https://laravel.com/docs/sail
-version: '3'
 services:
     laravel.test:
         build:


### PR DESCRIPTION
Since Compose file version 3 was moved to the legacy node (https://github.com/docker/docs/pull/14416), we should let Sail start supporting the Compose specification, which means letting the top-level version property be deprecated.

- https://docs.docker.com/compose/compose-file/
- https://docs.docker.com/compose/compose-file/04-version-and-name/

This also eliminates the need to keep an eye on whether the version of the Docker Compose file is out of date, as it will automatically be backwards compatible.