### PR TITLE
Add ./vendor/bin to the path in Dockerfile

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -53,7 +53,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
-ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/.bin"
 
 EXPOSE 8000
 

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -53,6 +53,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
 
 EXPOSE 8000
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -52,7 +52,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
-ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/.bin"
 
 EXPOSE 8000
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -52,6 +52,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
 
 EXPOSE 8000
 

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -52,6 +52,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
 
 EXPOSE 8000
 

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -52,7 +52,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
-ENV PATH "$PATH:.:./vendor/bin:./node_modules/bin"
+ENV PATH "$PATH:.:./vendor/bin:./node_modules/.bin"
 
 EXPOSE 8000
 


### PR DESCRIPTION
I added this line to  Dockerfile `ENV PATH "$PATH:.:./vendor/bin:./node_modules/.bin"`
With the expanded PATH variable, developers can run `sail shell` then execute key commands, such as `pest` and `phpstan` or running `artisan` without prefixing it with the php keyword.