### PR TITLE
[1.x] add `ti` alias for `tinker` command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -344,7 +344,7 @@ elif [ "$1" == "dusk:fails" ]; then
     fi
 
 # Initiate a Laravel Tinker session within the application container...
-elif [ "$1" == "tinker" ] ; then
+elif [ "$1" == "tinker" ] || [ "$1" == "ti" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then


### PR DESCRIPTION
Hello,

Similar to pull request #588 , this PR adds the `ti` alias for the `tinker` command.