### PR TITLE
[1.x] add `c` alias for `composer` command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -232,7 +232,7 @@ elif [ "$1" == "docker-compose" ]; then
     fi
 
 # Proxy Composer commands to the "composer" binary on the application container...
-elif [ "$1" == "composer" ]; then
+elif [ "$1" == "composer" ] || [ "$1" == "c" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then


### PR DESCRIPTION
Hello,

Similar to pull request #588, #603, this PR adds the `c` alias for the `composer` command.