### PR TITLE
Add PNPM support to enhance dependency management efficiency

### DIFF
--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sLS https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
-    && npm install -g npm \
+    && curl -fsSL https://get.pnpm.io/install.sh | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -sLS https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
+    && npm install -g npm \
     && curl -fsSL https://get.pnpm.io/install.sh | bash - \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
This PR aims to add support for PNPM in the Laravel development environment. PNPM is an alternative to npm and Yarn, designed to optimize the process of installing and managing dependencies.

 The reason is because it brings a number of benefits, most notably improved project performance through optimized resource utilization. By efficiently using shared packages, PNPM significantly reduces disk space consumption. Its extremely fast installation times result from dependency linking, while cache efficiency and low memory consumption contribute to an overall smoother development experience. 
 This will result in Laravel projects that are lighter and faster to download.
 
 I have also omitted the command `&& npm install -g npm \` as it is unnecessary. The Node image already includes the latest version of npm during the extraction process. This refinement simplifies configuration and ensures that the development environment has an up-to-date version of `npm` without redundancy.

- [https://pnpm.io/pnpm-vs-npm](url)
- [https://medium.com/pnpm/why-should-we-use-pnpm-75ca4bfe7d93](url)

