### PR TITLE
Custom App Service Name detection when adding new services

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -59,7 +59,7 @@ trait InteractsWithDockerComposeServices
                     return explode('=', $item);
                 }, $env);
                 $env = array_column($env, 1, 0);
-                $appService = $env['APP_SERVICE'] ?? null;
+                $appService = $env['APP_SERVICE'] ? trim($env['APP_SERVICE']) : null;
             }
         }
 


### PR DESCRIPTION
These changes significantly enhance the configurational flexibility of Laravel Sail's Docker Compose setup, particularly in environments with distinct service naming requirements.

Custom App Service Name Support: 

A mechanism is introduced to detect the application service (APP_SERVICE). The code initially attempts to retrieve the service name from Laravel's default environment file. In the absence of a custom service name, the default laravel.test is retained. When adding a new service or devcontainer, the warning message has been enhanced. It now indicates the customized application service name (if applicable), ensuring clarity and context for integrated system scenarios.

<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
