### PR TITLE
Make MEILISEARCH_NO_ANALYTICS environment variable available

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -132,6 +132,7 @@ trait InteractsWithDockerComposeServices
         if (in_array('meilisearch', $services)) {
             $environment .= "\nSCOUT_DRIVER=meilisearch";
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
+            $environment .= "\nMEILISEARCH_NO_ANALYTICS=false\n";
         }
 
         if (in_array('soketi', $services)) {

--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -2,6 +2,8 @@ meilisearch:
     image: 'getmeili/meilisearch:latest'
     ports:
         - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
+    environment:
+        MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
     volumes:
         - 'sail-meilisearch:/meili_data'
     networks:


### PR DESCRIPTION
Meilisearch per default collects anonymized data from users in order to improve their product as stated [here](https://www.meilisearch.com/docs/learn/what_is_meilisearch/telemetry).

For some European citizens and organizations, this is always some kind of a problem.
To address these concerns, Sail should provide the option to set OPT OUT by default in the `.env` if someone wants to use meilisearch.

