### PR TITLE
[1.x] Use Laravel Prompts when available

### DIFF
--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -37,7 +37,7 @@ class AddCommand extends Command
         } elseif ($this->option('no-interaction')) {
             $services = $this->defaultServices;
         } else {
-            $services = $this->gatherServicesWithSymfonyMenu();
+            $services = $this->gatherServicesInteractively();
         }
 
         if ($invalidServices = array_diff($services, $this->services)) {

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -33,11 +33,11 @@ trait InteractsWithDockerComposeServices
     protected $defaultServices = ['mysql', 'redis', 'selenium', 'mailpit'];
 
     /**
-     * Gather the desired Sail services using a Symfony menu.
+     * Gather the desired Sail services using an interactive prompt.
      *
      * @return array
      */
-    protected function gatherServicesWithSymfonyMenu()
+    protected function gatherServicesInteractively()
     {
         if (function_exists('\Laravel\Prompts\multiselect')) {
             return \Laravel\Prompts\multiselect(

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -39,6 +39,14 @@ trait InteractsWithDockerComposeServices
      */
     protected function gatherServicesWithSymfonyMenu()
     {
+        if (function_exists('\Laravel\Prompts\multiselect')) {
+            return \Laravel\Prompts\multiselect(
+                label: 'Which services would you like to install?',
+                options: $this->services,
+                default: ['mysql'],
+            );
+        }
+
         return $this->choice('Which services would you like to install?', $this->services, 0, null, true);
     }
 

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -38,7 +38,7 @@ class InstallCommand extends Command
         } elseif ($this->option('no-interaction')) {
             $services = $this->defaultServices;
         } else {
-            $services = $this->gatherServicesWithSymfonyMenu();
+            $services = $this->gatherServicesInteractively();
         }
 
         if ($invalidServices = array_diff($services, $this->services)) {


### PR DESCRIPTION
This PR updates the interactive service selection to use Laravel Prompts when available while maintaining support for Laravel 8 & 9. This works for the `sail:install` and `sail:add` commands.