### PR TITLE
[1.x] Add Bun

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -74,6 +74,11 @@ function display_help {
     echo "  ${GREEN}sail yarn ...${NC}        Run a Yarn command"
     echo "  ${GREEN}sail yarn run prod${NC}"
     echo
+    echo "${YELLOW}Bun Commands:${NC}"
+    echo "  ${GREEN}sail bun ...${NC}        Run a bun command"
+    echo "  ${GREEN}sail bunx${NC}           Run a bunx command"
+    echo "  ${GREEN}sail bun run prod${NC}"
+    echo
     echo "${YELLOW}Database Commands:${NC}"
     echo "  ${GREEN}sail mysql${NC}     Start a MySQL CLI session within the 'mysql' container"
     echo "  ${GREEN}sail mariadb${NC}   Start a MySQL CLI session within the 'mariadb' container"
@@ -428,6 +433,30 @@ elif [ "$1" == "yarn" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" yarn "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy Bun commands to the "bun" binary on the application container...
+elif [ "$1" == "bun" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" bun "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy Bun X commands to the "bunx" binary on the application container...
+elif [ "$1" == "bunx" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" bunx "$@")
     else
         sail_is_not_running
     fi

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm \
+    && curl -fsSL https://bun.sh/install | bash \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm \
+    && curl -fsSL https://bun.sh/install | bash \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g pnpm \
+    && curl -fsSL https://bun.sh/install | bash \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g pnpm \
+    && curl -fsSL https://bun.sh/install | bash \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \


### PR DESCRIPTION
[Bun](https://bun.sh/) is an all-in-one high performant toolkit for JavaScript which released 1.0 version after 2 years of development. It is used as:
- JavaScript runtime (Node.js replacement)
- Package manager (npm, yarn, pnpm replacement)
- Bundler (compatible with esbuild API)
- Test runner (replacement for vitest, jest etc)
- Package runner (replacement for npx, pnpx)

In addition to almost complete compatibility with Node.js API it introduces extra features as:
- Compatibility with both ESM and CJS syntax at the same time
- Support for TypeScript without transpilation
- Internal transpiler for JSX/TSX
- [JavaScript macros](https://bun.sh/blog/bun-macros)
- etc...

I think Bun is a nice tool even if only used as package manager, however I believe it may be considered as a primary bundler for Laravel in the future as well