### PR TITLE
Enable supervisorctl usage

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -98,11 +98,12 @@ function display_help {
     echo "  ${GREEN}sail dusk:fails${NC}    Re-run previously failed Dusk tests (Requires the laravel/dusk package)"
     echo
     echo "${YELLOW}Container CLI:${NC}"
-    echo "  ${GREEN}sail shell${NC}        Start a shell session within the application container"
-    echo "  ${GREEN}sail bash${NC}         Alias for 'sail shell'"
-    echo "  ${GREEN}sail root-shell${NC}   Start a root shell session within the application container"
-    echo "  ${GREEN}sail root-bash${NC}    Alias for 'sail root-shell'"
-    echo "  ${GREEN}sail tinker${NC}       Start a new Laravel Tinker session"
+    echo "  ${GREEN}sail shell${NC}           Start a shell session within the application container"
+    echo "  ${GREEN}sail bash${NC}            Alias for 'sail shell'"
+    echo "  ${GREEN}sail root-shell${NC}      Start a root shell session within the application container"
+    echo "  ${GREEN}sail root-bash${NC}       Alias for 'sail root-shell'"
+    echo "  ${GREEN}sail supervisorctl${NC}   Start a supervisorctl shell within the application container"
+    echo "  ${GREEN}sail tinker${NC}          Start a new Laravel Tinker session"
     echo
     echo "${YELLOW}Sharing:${NC}"
     echo "  ${GREEN}sail share${NC}   Share the application publicly via a temporary URL"
@@ -520,6 +521,18 @@ elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" bash "$@")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy supervisorctl commands to the "supervisorctl" binary on the application container...
+elif [ "$1" == "supervisorctl" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" supervisorctl "$@")
     else
         sail_is_not_running
     fi

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+chown=sail
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+chown=sail
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+chown=sail
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -4,6 +4,13 @@ user=root
 logfile=/var/log/supervisor/supervisord.log
 pidfile=/var/run/supervisord.pid
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+chown=sail
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 [program:php]
 command=/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80
 user=sail


### PR DESCRIPTION
This pull request enables the RPC functionality of supervisord, making you able to control the processes that are managed by supervisord inside the application container. This pull request will also add a sub command to the sail shell script to interact with supervisorctl directly instead of going through a shell (`./vendor/bin/sail shell` or the likes) .

Example usage:
`./vendor/bin/sail supervisorctl`
`./vendor/bin/sail supervisorctl restart php`
`./vendor/bin/sail supervisorctl --help`

This change doesn't expose any additional ports as a UNIX socket is used. That socket is owned by the sail user so the security implications should be minimal, if any. The only noticeable change for the end user would be the new command in the sail shell script.

This will add value for those debugging the internals of the sail container and especially to those who have published the Dockerfiles and added their own programs to supervisord. It's also a possible timesave to have direct access towards the supervisorctl binary, and that it works out of the box.

Fixes #584 
