### PR TITLE
Fix: Allow postCreateCommand to fail silently in VS Code on Windows

### DIFF
--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -19,7 +19,7 @@
 		}
 	},
 	"remoteUser": "sail",
-	"postCreateCommand": "chown -R 1000:1000 /var/www/html"
+	"postCreateCommand": "chown -R 1000:1000 /var/www/html 2>/dev/null || true"
 	// "forwardPorts": [],
 	// "runServices": [],
 	// "shutdownAction": "none",


### PR DESCRIPTION
There is an issue for Windows users when using Dev Containers from VS Code. This issue will not be seen by Linux users.

When a Laravel project is created with the curl command which includes the `&devcontainer` option, similar to this:

`curl -s "https://laravel.build/my-project-name?with=mysql,redis,meilisearch,mailpit,selenium&devcontainer" | bash`

The file `devcontainer.json` includes the following line:

`"postCreateCommand": "chown -R 1000:1000 /var/www/html"`

As the files that are created inside a container (by VS Code) are automatically created as though the owner is `root` (due to complications with drives/folders mapped from Windows to a Linux container), the line above will fail to change the permissions of the files beneath `/var/www/html`. Finally the command will conclude with an error due to a non-zero return code.

Not only does this worry the user into thinking that there has been a serious error (when actually the error can be ignored), if the user adds any further postCreateCommands, they will fail to execute.

The resolution I have applied is to supress the output from the `chown` command and to force it to return 0 (non-error). This will make the output look clean and will allow any further postCreateCommands to proceed.

The other option is to delete the line for Windows users, but it is better if the line is common between different OS's.

The down side is that if there is a real error when running the line on non-Windows machines, the user will not see the error reported.