### PR TITLE
Allow debugging pest command with XDEBUG

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -92,7 +92,7 @@ function display_help {
     echo "${YELLOW}Running Tests:${NC}"
     echo "  ${GREEN}sail test${NC}          Run the PHPUnit tests via the Artisan test command"
     echo "  ${GREEN}sail phpunit ...${NC}   Run PHPUnit"
-    echo "  ${GREEN}sail pest ...${NC}      Run Pest"
+    echo "  ${GREEN}sail pest ...${NC}      Run Pest (run with -xdebug to start a XDEBUG session"
     echo "  ${GREEN}sail pint ...${NC}      Run Pint"
     echo "  ${GREEN}sail dusk${NC}          Run the Dusk tests (Requires the laravel/dusk package)"
     echo "  ${GREEN}sail dusk:fails${NC}    Re-run previously failed Dusk tests (Requires the laravel/dusk package)"
@@ -307,6 +307,10 @@ elif [ "$1" == "pest" ]; then
 
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
+        if [[ "$1" == "-xdebug" ]];then
+          ARGS+=(-e XDEBUG_SESSION=1)
+          shift 1
+        fi
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" php vendor/bin/pest "$@")
     else


### PR DESCRIPTION
## WHAT IS THIS ABOUT?
Allow passing `debug` argument to `sail pest` like this `sail pest -xdebug` so we can start an interactive debug session from the command line

### MOTIVATION
I'm using `nvim` to develop PHP Laravel applications. So far debugging is working when running the request through http. But today I wanted to run tests with `pest` and I saw is not posible for me to start a debugging session from the command line `sail pest` without setting `XDEBUG_SESSION=1`. Digging into the code I tried this 

```
docker-compose exec -u sail -e XDEBUG_SESSION=1 laravel.test  php vendor/bin/pest
```
And it worked 🎉 So I though maybe this could be also helpful for other people. 

The idea is to allow passing the `-xdebug` flag to `pest` sail command like this

```
sail pest -xdebug
```
And this will start a XDEBUG session that nvim is able to attach to.

### Help 
Please let me know first if this change makes sense. And if it makes sense what should I do to ensure this comply with the quality standards of the project. For example. Do I need to add some kind of tests? I didn't see any folder in the sail project. 