### PR TITLE
Support Laravel 11 and update dependencies

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
 
       - name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v3
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
         with:
           severity: warning
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,11 @@
     ],
     "require": {
         "php": "^8.0",
-        "illuminate/console": "^8.0|^9.0|^10.0",
-        "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "illuminate/support": "^8.0|^9.0|^10.0",
-        "symfony/yaml": "^6.0"
+        "illuminate/console": "^9.0|^10.0|^11.0",
+        "illuminate/contracts": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
+        "laravel/framework": "^11.0",
+        "symfony/yaml": "^6.0|^7.0"
     },
     "bin": [
         "bin/sail"
@@ -44,7 +45,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "orchestra/testbench": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "phpstan/phpstan": "^1.10"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "illuminate/console": "^9.0|^10.0|^11.0",
         "illuminate/contracts": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
-        "laravel/framework": "^11.0",
         "symfony/yaml": "^6.0|^7.0"
     },
     "bin": [


### PR DESCRIPTION
This PR adds Support for Laravel 11 and Symfony 7.

- `symfony/yaml:^7.0` has no breaking changes it seems: https://github.com/symfony/yaml/blob/7.0/CHANGELOG.md
- Laravel 8 uses Symfony 5 and is already not supported anymore, therefor being dropped here (orchestra/testbench is updated accordingly)
- Updated some versions in Github Actions

Because Laravel Sail doesn't have Tests, I manually checked the installation on Laravel 11 using the following script: (Requirements: Docker is running, PHP8.2 is used)

```
laravel new sail-laravel11 --dev --no-interaction
cd sail-laravel11
composer config repositories.sail vcs https://github.com/Jubeki/laravel-sail.git
composer require laravel/sail:dev-laravel11 --dev
php artisan sail:install --with=mysql

vendor/bin/sail up -d --wait
vendor/bin/sail artisan migrate
open http://localhost
```

Please don't forget to stop the docker container after testing:
```
vendor/bin/sail down
```