### PR TITLE
Update Dockerfile

### DIFF
--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.1-cli php8.1-dev \
+    && apt-get install -y php8.1.24-cli php8.1.24-dev \
        php8.1-pgsql php8.1-sqlite3 php8.1-gd php8.1-imagick \
        php8.1-curl \
        php8.1-imap php8.1-mysql php8.1-mbstring \


### PR DESCRIPTION
v8.1.12 is installed by default.

Most packages require php 8.1.17 and above.