### PR TITLE
[1.x] Add missing PHP 8.3 extensions

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -26,9 +26,9 @@ RUN apt-get update \
        php8.3-xml php8.3-zip php8.3-bcmath php8.3-soap \
        php8.3-intl php8.3-readline \
        php8.3-ldap \
-       # php8.3-msgpack php8.3-igbinary php8.3-redis php8.3-swoole \
-       # php8.3-memcached php8.3-pcov php8.3-xdebug \
-       # php8.3-imagick \
+       php8.3-msgpack php8.3-igbinary php8.3-redis php8.3-swoole \
+       php8.3-memcached php8.3-pcov php8.3-imagick \
+       # php8.3-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
ppa of ondrej includes most of the currently not included extensions for PHP 8.3 excluding php-xdebug.

this PR adds them to Dockerfile of 8.3