### PR TITLE
[1.x] [#651] Don't do anything if no phpunit files are present

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -170,6 +170,9 @@ trait InteractsWithDockerComposeServices
     {
         if (! file_exists($path = $this->laravel->basePath('phpunit.xml'))) {
             $path = $this->laravel->basePath('phpunit.xml.dist');
+            if(! file_exists($path)) {
+                return;
+            }
         }
 
         $phpunit = file_get_contents($path);

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -170,7 +170,8 @@ trait InteractsWithDockerComposeServices
     {
         if (! file_exists($path = $this->laravel->basePath('phpunit.xml'))) {
             $path = $this->laravel->basePath('phpunit.xml.dist');
-            if(! file_exists($path)) {
+
+            if (! file_exists($path)) {
                 return;
             }
         }


### PR DESCRIPTION
Add a check to confirm the fallback path exists before trying to use it when updating phpunit files to point to the new database
