### PR TITLE
Add Support for Typesense

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -19,6 +19,7 @@ trait InteractsWithDockerComposeServices
         'redis',
         'memcached',
         'meilisearch',
+        'typesense',
         'minio',
         'mailpit',
         'selenium',
@@ -86,7 +87,7 @@ trait InteractsWithDockerComposeServices
         // Merge volumes...
         collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'minio']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'redis', 'meilisearch', 'typesense', 'minio']);
             })->filter(function ($service) use ($compose) {
                 return ! array_key_exists($service, $compose['volumes'] ?? []);
             })->each(function ($service) use (&$compose) {
@@ -141,6 +142,14 @@ trait InteractsWithDockerComposeServices
             $environment .= "\nSCOUT_DRIVER=meilisearch";
             $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
             $environment .= "\nMEILISEARCH_NO_ANALYTICS=false\n";
+        }
+
+        if (in_array('typesense', $services)) {
+            $environment .= "\nSCOUT_DRIVER=typesense";
+            $environment .= "\nTYPESENSE_HOST=typesense";
+            $environment .= "\nTYPESENSE_PORT=8108";
+            $environment .= "\nTYPESENSE_PROTOCOL=http";
+            $environment .= "\nTYPESENSE_API_KEY=xyz\n";
         }
 
         if (in_array('soketi', $services)) {

--- a/stubs/typesense.stub
+++ b/stubs/typesense.stub
@@ -1,0 +1,16 @@
+typesense:
+    image: 'typesense/typesense:0.25.2'
+    ports:
+        - '${FORWARD_TYPESENSE_PORT:-8108}:8108'
+    environment:
+        TYPESENSE_DATA_DIR: '${TYPESENSE_DATA_DIR:-/typesense-data}'
+        TYPESENSE_API_KEY: '${TYPESENSE_API_KEY:-xyz}'
+        TYPESENSE_ENABLE_CORS: '${TYPESENSE_ENABLE_CORS:-true}'
+    volumes:
+        - 'sail-typesense:/typesense-data'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:8108/health"]
+        retries: 5
+        timeout: 7s


### PR DESCRIPTION
This PR adds support for [Typesense](https://github.com/typesense/typesense) to Sail, so users can easily get a local instance of Typesense running to use with the new [Scout Typesense integration](https://github.com/laravel/scout/pull/773).

Related docs PR: https://github.com/laravel/docs/pull/9262
