### PR TITLE
Update sail to support custom docker image names

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -138,6 +138,10 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export PGSQL_SERVICE=${PGSQL_SERVICE:-"pgsql"}
+export MARIADB_SERVICE=${MARIADB_SERVICE:-"mariadb"}
+export MYSQL_SERVICE=${MYSQL_SERVICE:-"mysql"}
+export REDIS_SERVICE=${REDIS_SERVICE:-"redis"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
@@ -468,7 +472,7 @@ elif [ "$1" == "mysql" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(mysql bash -c)
+        ARGS+=("$MYSQL_SERVICE" bash -c)
         ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
     else
         sail_is_not_running
@@ -481,7 +485,7 @@ elif [ "$1" == "mariadb" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(mariadb bash -c)
+        ARGS+=("$MARIADB_SERVICE" bash -c)
         ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
     else
         sail_is_not_running
@@ -494,7 +498,7 @@ elif [ "$1" == "psql" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(pgsql bash -c)
+        ARGS+=("$PGSQL_SERVICE" bash -c)
         ARGS+=("PGPASSWORD=\${PGPASSWORD} psql -U \${POSTGRES_USER} \${POSTGRES_DB}")
     else
         sail_is_not_running
@@ -531,7 +535,7 @@ elif [ "$1" == "redis" ] ; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=(redis redis-cli)
+        ARGS+=("$REDIS_SERVICE" redis-cli)
     else
         sail_is_not_running
     fi

--- a/bin/sail
+++ b/bin/sail
@@ -138,11 +138,12 @@ fi
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
-export PGSQL_SERVICE=${PGSQL_SERVICE:-"pgsql"}
+export DB_PORT=${DB_PORT:-3306}
 export MARIADB_SERVICE=${MARIADB_SERVICE:-"mariadb"}
 export MYSQL_SERVICE=${MYSQL_SERVICE:-"mysql"}
+export PGSQL_SERVICE=${PGSQL_SERVICE:-"pgsql"}
 export REDIS_SERVICE=${REDIS_SERVICE:-"redis"}
-export DB_PORT=${DB_PORT:-3306}
+export SELENIUM_SERVICE=${SELENIUM_SERVICE:-"selenium"}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
 
@@ -337,7 +338,7 @@ elif [ "$1" == "dusk" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
-        ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+        ARGS+=(-e "DUSK_DRIVER_URL=http://${SELENIUM_SERVICE}:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk "$@")
     else
         sail_is_not_running
@@ -351,7 +352,7 @@ elif [ "$1" == "dusk:fails" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
-        ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
+        ARGS+=(-e "DUSK_DRIVER_URL=http://${SELENIUM_SERVICE}:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
     else
         sail_is_not_running


### PR DESCRIPTION
This PR let user choose the name of docker services instead of defaults (as already done for `APP_SERVICE`)

We use several laravel apps communicating together via an API. Developers run these apps at the same time on their machines and they need to specify distinct names for databases, redis, ... in their env. eg:

- `app_laravel`
- `cms_laravel`
- `crm_laravel`
- `app_redis`
- `cms_redis`
- `crm_redis`
- ...

On each project, this PR let you set these variables in your `.env` file. eg:

```env
APP_SERVICE=app_laravel
PGSQL_SERVICE=app_pgsql
REDIS_SERVICE=app_redis
SELENIUM_SERVICE=app_selenium
```