### PR TITLE
Fix open in browser with APP_PORT

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -567,7 +567,6 @@ elif [ "$1" == "open" ]; then
             FULL_URL="$APP_URL"
         fi
 
-        # Open the URL
         open "$FULL_URL"
 
         exit

--- a/bin/sail
+++ b/bin/sail
@@ -560,7 +560,15 @@ elif [ "$1" == "open" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
-        open "$APP_URL"
+
+        if [[ -n "$APP_PORT" && "$APP_PORT" != "80" ]]; then
+            FULL_URL="${APP_URL}:${APP_PORT}"
+        else
+            FULL_URL="$APP_URL"
+        fi
+
+        # Open the URL
+        open "$FULL_URL"
 
         exit
     else


### PR DESCRIPTION
When a env variable for `APP_PORT` is defined (to something else than 80), then the site won't open correctly on the `sail open` command.

This PR adds a simple check:
- If `APP_PORT` is set and not to 80, then the `FULL_URL` gets the port added.
- else `FULL_URL` is set as before

Finally, open `FULL_URL`.

