### PR TITLE
[1.x] Switch from XDEBUG_SESSION to XDEBUG_TRIGGER for sail debug

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -270,7 +270,7 @@ elif [ "$1" == "debug" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
-        ARGS+=(exec -u sail -e XDEBUG_SESSION=1)
+        ARGS+=(exec -u sail -e XDEBUG_TRIGGER=1)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" php artisan "$@")
     else


### PR DESCRIPTION
## Background 
XDEBUG_SESSION is described as a legacy trigger for step debugging in the Xdebug documentation. See the below excerpt from the section on [xdebug.start_with_request](https://xdebug.org/docs/step_debug#start_with_request) for the trigger setting:

"The functionality only gets activated when a specific trigger is present when the request starts.

The name of the trigger is XDEBUG_TRIGGER, and Xdebug checks for its presence in either $_ENV (environment variable), $_GET or $_POST variable, or $_COOKIE (HTTP cookie name).

There is a legacy fallback to a functionality specific trigger name: XDEBUG_PROFILE (for Profiling), XDEBUG_TRACE (for a Function Trace), and XDEBUG_SESSION (for Step Debugging)."

## Reasoning behind this change
By changing sail debug to use XDEBUG_TRIGGER=1, it'll be in-line with the recommended usage for Xdebug 3 and will be protected against any removal of these "legacy fallbacks".

Additionally, it will allow those using Xdebug profiler via sail to use it in trigger mode, as XDEBUG_TRIGGER works for the the profiler as well as the step debugger.  XDEBUG_SESSION does not activate the profiler. To use the profiler via a trigger, you currently have to do something like `sail bash -c "XDEBUG_TRIGGER=1 php artisan app:example"`, which is a bit clunky.             

## Breaking changes
There should be no breaking changes with this PR as XDEBUG_TRIGGER will activate the step debugger just like XDEBUG_SESSION does. All of the Sail PHP images are using Xdebug 3, so there shouldn't be an issue with some users still using Xdebug 2 via Sail.