### PR TITLE
Allow building sail to run PHP as root

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /var/www/html
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
+ENV SUPERVISOR_PHP_USER="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$SUPERVISOR_PHP_USER" != "root" ] && [ "$SUPERVISOR_PHP_USER" != "sail" ]; then
+    echo "You should set SUPERVISOR_PHP_USER to either 'sail' or 'root'."
+    exit 1
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
@@ -11,7 +16,11 @@ fi
 chmod -R ugo+rw /.composer
 
 if [ $# -gt 0 ]; then
-    exec gosu $WWWUSER "$@"
+    if [ "$SUPERVISOR_PHP_USER" = "root" ]; then
+        exec "$@"
+    else
+        exec gosu $WWWUSER "$@"
+    fi
 else
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -6,7 +6,7 @@ pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=%(ENV_SUPERVISOR_PHP_COMMAND)s
-user=sail
+user=%(ENV_SUPERVISOR_PHP_USER)s
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /var/www/html
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
+ENV SUPERVISOR_PHP_USER="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$SUPERVISOR_PHP_USER" != "root" ] && [ "$SUPERVISOR_PHP_USER" != "sail" ]; then
+    echo "You should set SUPERVISOR_PHP_USER to either 'sail' or 'root'."
+    exit 1
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
@@ -11,7 +16,11 @@ fi
 chmod -R ugo+rw /.composer
 
 if [ $# -gt 0 ]; then
-    exec gosu $WWWUSER "$@"
+    if [ "$SUPERVISOR_PHP_USER" = "root" ]; then
+        exec "$@"
+    else
+        exec gosu $WWWUSER "$@"
+    fi
 else
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -6,7 +6,7 @@ pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=%(ENV_SUPERVISOR_PHP_COMMAND)s
-user=sail
+user=%(ENV_SUPERVISOR_PHP_USER)s
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /var/www/html
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
+ENV SUPERVISOR_PHP_USER="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.2/start-container
+++ b/runtimes/8.2/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$SUPERVISOR_PHP_USER" != "root" ] && [ "$SUPERVISOR_PHP_USER" != "sail" ]; then
+    echo "You should set SUPERVISOR_PHP_USER to either 'sail' or 'root'."
+    exit 1
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
@@ -11,7 +16,11 @@ fi
 chmod -R ugo+rw /.composer
 
 if [ $# -gt 0 ]; then
-    exec gosu $WWWUSER "$@"
+    if [ "$SUPERVISOR_PHP_USER" = "root" ]; then
+        exec "$@"
+    else
+        exec gosu $WWWUSER "$@"
+    fi
 else
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -6,7 +6,7 @@ pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=%(ENV_SUPERVISOR_PHP_COMMAND)s
-user=sail
+user=%(ENV_SUPERVISOR_PHP_USER)s
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /var/www/html
 ENV DEBIAN_FRONTEND noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
+ENV SUPERVISOR_PHP_USER="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/runtimes/8.3/start-container
+++ b/runtimes/8.3/start-container
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$SUPERVISOR_PHP_USER" != "root" ] && [ "$SUPERVISOR_PHP_USER" != "sail" ]; then
+    echo "You should set SUPERVISOR_PHP_USER to either 'sail' or 'root'."
+    exit 1
+fi
+
 if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
@@ -11,7 +16,11 @@ fi
 chmod -R ugo+rw /.composer
 
 if [ $# -gt 0 ]; then
-    exec gosu $WWWUSER "$@"
+    if [ "$SUPERVISOR_PHP_USER" = "root" ]; then
+        exec "$@"
+    else
+        exec gosu $WWWUSER "$@"
+    fi
 else
     exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
 fi

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -6,7 +6,7 @@ pidfile=/var/run/supervisord.pid
 
 [program:php]
 command=%(ENV_SUPERVISOR_PHP_COMMAND)s
-user=sail
+user=%(ENV_SUPERVISOR_PHP_USER)s
 environment=LARAVEL_SAIL="1"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0


### PR DESCRIPTION
Hi,

Today, I tried running Sail in a rootless Podman container, and the experience was less-than-ideal. You might better recognize the class of issues as being similar to Docker Desktop - this would be precisely right: it's the same all over again.

The reason boils down to the follow: the image, as it is laid out currently, has its entrypoint running as root, and its main functionality (i.e. php) running as the sail user. This means that root inside the container is the host user I'm using to run the container, and sail is some random UID.

Some relevant supporting documentation and references to previous issues:

- [Rootless containers with Podman: The basics](https://developers.redhat.com/blog/2020/09/25/rootless-containers-with-podman-the-basics) -- from Red Hat, Recaps the basics of rootless containers and why running rootless containers is a good thing
- [Understanding rootless Podman's user namespace modes](https://www.redhat.com/sysadmin/rootless-podman-user-namespace-modes) -- from Red Hat, explains the issue of Linux's user namespaces very effectively
- #81 #459 #536 #548 etc.

The proposed proof-of-concept patch simply allows setting the `$SUPERVISOR_PHP_USER` env variable to run PHP in the container as root. Users should be instructed about this by the "getting started" documentation, to avoid spending an evening figuring it out (or not) like I just did.

In my opinion this is the only valid long-term solution for rootless containers, as:

- There is a lot of voodoo around the web and even in some of the issues linked above. The bottom line is that rootless unprivileged users (like `sail` in the sail container) have an effective ("host") UID that will *not* in any case be able to access /var/www/html (i.e. the user's project files), regardless of the value of `--userns`, if the files themselves are not chowned to this unprivileged by either Podman (U flag for bind mounts) or something running on the host. This is because root in the container is mapped to the user launching the container, and all other uids in the container are mapped to random junk host uids (usually >100000). It's simple to test this: open a root shell in a Sail container, and run `touch /var/www/html/example && chown sail:sail /var/www/html/example`; go on that directory outside the container, the UID will be some junk number. You can also run `cat /proc/self/uid_map` inside the container to see the mapping
- For that exact reason, bind mounts are only accessible by root inside the containers (unless the files in the bind mounts have world r/w permissions of course)
- It follows from this that PHP in Sail rootless containers should run as root

This will effectively make PHP have the permissions and capabilities of the launching user, which imho is the standard expectation for a dev environment. Furthermore, in a world where people don't just go around launching containers as root, this would also be a sensible default setting, but since the real world is the insurmountable single point of truth I won't advocate for that.

So, to recap:
- By default, rootless containers map root in the container to the user running the container (meets expectations: Laravel runs as the user who launches the command)
- Root inside a rootless container is NOT root on the host, even if it escapes the container (secure)
- This patch adds support to build the Sail container to run rootless
- If the idea accepted, the patch should, at a minimum, be should be supplemented by adequate documentation
- If you want to pursue this but you feel like the patch is not adequate, please feel free to request any changes that would make the patch more adherent to your coding customs; I will be glad to oblige