### PR TITLE
Update MAILER config to use mailpit on L11

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -185,6 +185,7 @@ trait InteractsWithDockerComposeServices
         }
 
         if (in_array('mailpit', $services)) {
+            $environment = preg_replace("/^MAIL_MAILER=(.*)/m", "MAIL_MAILER=smtp", $environment);
             $environment = preg_replace("/^MAIL_HOST=(.*)/m", "MAIL_HOST=mailpit", $environment);
             $environment = preg_replace("/^MAIL_PORT=(.*)/m", "MAIL_PORT=1025", $environment);
         }

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -186,6 +186,7 @@ trait InteractsWithDockerComposeServices
 
         if (in_array('mailpit', $services)) {
             $environment = preg_replace("/^MAIL_HOST=(.*)/m", "MAIL_HOST=mailpit", $environment);
+            $environment = preg_replace("/^MAIL_PORT=(.*)/m", "MAIL_PORT=1025", $environment);
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
### Why?
Laravel 11 ships with the `log` driver as the default driver. 

In Laravel 10, the default `MAIL_PORT` and `MAIL_MAILER` values matched the values expected to work with mailpit out of the box hence these values were not necessary to update.

Running `php artisan sail:install --with mailpit` on a fresh Laravel 11 project results in the following `.env` config

```env
MAIL_MAILER=log
MAIL_HOST=mailpit
MAIL_PORT=2525
```

This still sends the emails to the log file for a user installing mailpit with sail in Laravel 11. This PR improves that DX by configuring the application to use mailpit by default for said users out of the box.

