### PR TITLE
[1.x] DB_DATABASE is not allways laravel

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -123,7 +123,7 @@ trait InteractsWithDockerComposeServices
             $defaults = [
                 '# DB_HOST=127.0.0.1',
                 '# DB_PORT=3306',
-                '# DB_DATABASE=laravel',
+                '# DB_DATABASE=',
                 '# DB_USERNAME=root',
                 '# DB_PASSWORD=',
             ];


### PR DESCRIPTION
DB_DATABASE is not allways laravel, see https://github.com/laravel/installer/blob/fec8b4e73a0a535ad9809a3eb8c365943707f845/src/NewCommand.php#L302

This PR fix #681 