### PR TITLE
Revert opcache for CLI

### DIFF
--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.2/php.ini
+++ b/runtimes/8.2/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.3/php.ini
+++ b/runtimes/8.3/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1


### PR DESCRIPTION
We've had several issues for installing Jetstream, etc because opcache was caching certain files:

https://github.com/laravel/jetstream/issues/1454
https://github.com/laravel/jetstream/issues/1451
https://github.com/laravel/octane/issues/858

@jessarcher has already worked on a potential fix to invalidate the opcache file before installing the provider: https://github.com/laravel/framework/pull/50665

But I feel like the original PR https://github.com/laravel/sail/pull/569 was a mistake (sorry @lukeraymonddowning!) as [it's simply not recommended to have opcache enabled on CLI](https://github.com/nextcloud/documentation/issues/1439).

People can still enable this on their own if they want to.