### PR TITLE
Fix permission for storage directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/sail/compare/v1.29.0...1.x)
+## [Unreleased](https://github.com/laravel/sail/compare/v1.29.1...1.x)
+
+## [v1.29.1](https://github.com/laravel/sail/compare/v1.29.0...v1.29.1) - 2024-03-20
+
+* [1.x] Make commands lazy by [@timacdonald](https://github.com/timacdonald) in https://github.com/laravel/sail/pull/683
+* Preinstall nano, so default make tinker edit work out of the box by [@negoziator](https://github.com/negoziator) in https://github.com/laravel/sail/pull/685
+* Revert opcache for CLI by [@driesvints](https://github.com/driesvints) in https://github.com/laravel/sail/pull/684
 
 ## [v1.29.0](https://github.com/laravel/sail/compare/v1.28.2...v1.29.0) - 2024-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Release Notes
 
-## [Unreleased](https://github.com/laravel/sail/compare/v1.28.2...1.x)
+## [Unreleased](https://github.com/laravel/sail/compare/v1.29.0...1.x)
+
+## [v1.29.0](https://github.com/laravel/sail/compare/v1.28.2...v1.29.0) - 2024-03-08
+
+* Allow building sail to run PHP as root by [@vmsh0](https://github.com/vmsh0) in https://github.com/laravel/sail/pull/677
+* Update MAILER config to use mailpit on L11 by [@SamuelMwangiW](https://github.com/SamuelMwangiW) in https://github.com/laravel/sail/pull/678
 
 ## [v1.28.2](https://github.com/laravel/sail/compare/v1.28.1...v1.28.2) - 2024-03-04
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "illuminate/console": "^9.52.16|^10.0|^11.0",
         "illuminate/contracts": "^9.52.16|^10.0|^11.0",
         "illuminate/support": "^9.52.16|^10.0|^11.0",
+        "symfony/console": "^6.0|^7.0",
         "symfony/yaml": "^6.0|^7.0"
     },
     "bin": [

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg nano \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu focal main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \

--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -14,6 +14,7 @@ if [ ! -d /.composer ]; then
 fi
 
 chmod -R ugo+rw /.composer
+chmod -R ugo+rw ./storage
 
 if [ $# -gt 0 ]; then
     if [ "$SUPERVISOR_PHP_USER" = "root" ]; then

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg nano \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -14,6 +14,7 @@ if [ ! -d /.composer ]; then
 fi
 
 chmod -R ugo+rw /.composer
+chmod -R ugo+rw ./storage
 
 if [ $# -gt 0 ]; then
     if [ "$SUPERVISOR_PHP_USER" = "root" ]; then

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg nano  \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \

--- a/runtimes/8.2/php.ini
+++ b/runtimes/8.2/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.2/start-container
+++ b/runtimes/8.2/start-container
@@ -14,6 +14,7 @@ if [ ! -d /.composer ]; then
 fi
 
 chmod -R ugo+rw /.composer
+chmod -R ugo+rw ./storage
 
 if [ $# -gt 0 ]; then
     if [ "$SUPERVISOR_PHP_USER" = "root" ]; then

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -17,7 +17,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python2 dnsutils librsvg2-bin fswatch ffmpeg nano  \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x14aa40ec0831756756d7f66c4f4ea0aae5267a6c' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu jammy main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \

--- a/runtimes/8.3/php.ini
+++ b/runtimes/8.3/php.ini
@@ -3,6 +3,3 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
-
-[opcache]
-opcache.enable_cli=1

--- a/runtimes/8.3/start-container
+++ b/runtimes/8.3/start-container
@@ -14,6 +14,7 @@ if [ ! -d /.composer ]; then
 fi
 
 chmod -R ugo+rw /.composer
+chmod -R ugo+rw ./storage
 
 if [ $# -gt 0 ]; then
     if [ "$SUPERVISOR_PHP_USER" = "root" ]; then

--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -4,7 +4,9 @@ namespace Laravel\Sail\Console;
 
 use Illuminate\Console\Command;
 use Laravel\Sail\Console\Concerns\InteractsWithDockerComposeServices;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sail:add')]
 class AddCommand extends Command
 {
     use InteractsWithDockerComposeServices;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -4,8 +4,10 @@ namespace Laravel\Sail\Console;
 
 use Illuminate\Console\Command;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Process\Process;
 
+#[AsCommand(name: 'sail:install')]
 class InstallCommand extends Command
 {
     use Concerns\InteractsWithDockerComposeServices;

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -3,7 +3,9 @@
 namespace Laravel\Sail\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'sail:publish')]
 class PublishCommand extends Command
 {
     /**


### PR DESCRIPTION
This pull request resolves the issue of Laravel's storage directory permissions for the user group, fixing the error where the log file (`/var/www/html/storage/logs/laravel.log`) could not be opened in append mode due to permission denial, by adding `ugo+rw` permission to the storage directory of Laravel.

This fix does not break any existing features as it specifically targets the permission settings within the storage directory, ensuring that necessary write operations can be performed without affecting the functionality of other features or components within the Laravel application.

Thanks.