### PR TITLE
[1.x] Install "mariadb-client" package for MariaDB users

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="Taylor Otwell"
 
 ARG WWWGROUP
 ARG NODE_VERSION=20
+ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=15
 
 WORKDIR /var/www/html
@@ -44,7 +45,7 @@ RUN apt-get update \
     && echo "deb [signed-by=/etc/apt/keyrings/pgdg.gpg] http://apt.postgresql.org/pub/repos/apt jammy-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
     && apt-get update \
     && apt-get install -y yarn \
-    && apt-get install -y mysql-client \
+    && apt-get install -y $MYSQL_CLIENT \
     && apt-get install -y postgresql-client-$POSTGRES_VERSION \
     && apt-get -y autoremove \
     && apt-get clean \

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -65,6 +65,11 @@ trait InteractsWithDockerComposeServices
             ? Yaml::parseFile($composePath)
             : Yaml::parse(file_get_contents(__DIR__ . '/../../../stubs/docker-compose.stub'));
 
+        // Prepare the installation of the "mariadb-client" package if the MariaDB service is used...
+        if (in_array('mariadb', $services)) {
+            $compose['services']['laravel.test']['build']['args']['MYSQL_CLIENT'] = 'mariadb-client';
+        }
+
         // Adds the new services as dependencies of the laravel.test service...
         if (! array_key_exists('laravel.test', $compose['services'])) {
             $this->warn('Couldn\'t find the laravel.test service. Make sure you add ['.implode(',', $services).'] to the depends_on config.');


### PR DESCRIPTION
This PR is related to https://github.com/laravel/framework/pull/51355:
We need to switch the MariaDB's driver dump binary from `mysqldump` to `mariadb-dump` at some point as MariaDB will remove its support for `mysqldump`. The issue is that Sail doesn't support `mariadb-dump` yet.

I looked into using the dump binaries from the actual `mysql`/`mariadb` containers, but that's a nightmare. 

Instead, my suggestion is to install the `mariadb-client` package instead of `mysql-client` in the app container when the MariaDB service is requested. This package provides the necessary `mariadb-dump` binary.

As discussed with @driesvints in the other PR, we should only switch to `mariadb-dump` in Laravel 12 and this PR prepares Sail for that switch. I only adjusted the `Dockerfile` for PHP 8.3 as I assumed that Laravel 12 will drop support for PHP 8.2.

I don't see any breaking changes for Sail users:
- With the default value `MYSQL_CLIENT="mysql-client"`, nothing changes for existing users after updating to the latest version.
- For Sail users that set up a MariaDB app after this PR is released, the dump command will continue working since the `mariadb-client` package creates a symlink `mysqldump -> mariadb-dump`.

@driesvints What do you think about this approach?