### PR TITLE
Update mysql.stub to restart if fails according to health check

### DIFF
--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -18,3 +18,4 @@ mysql:
         test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
         retries: 3
         timeout: 5s
+    restart: unless-stopped


### PR DESCRIPTION
Mysql may shut down after some time. Healthcheck keys are configured, but no action takes place when the server fail. The directive "restart: unless-stopped" will restart the database server if the watchdogs barks.