### PR TITLE
Update mariadb.stub

### DIFF
--- a/stubs/mariadb.stub
+++ b/stubs/mariadb.stub
@@ -18,3 +18,4 @@ mariadb:
         test: ["CMD", "mysqladmin", "ping", "-p${DB_PASSWORD}"]
         retries: 3
         timeout: 5s
+    restart: unless-stopped


### PR DESCRIPTION
Mariadb may shut down after some time. Healthcheck keys are configured, but no action takes place when the server fail. The directive "restart: unless-stopped" will restart the database server if the watchdogs barks. Similar to PR #695 