### PR TITLE
Fix meilisearch healthcheck gets to IPv6 instead IPv4

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -9,6 +9,6 @@ meilisearch:
     networks:
         - sail
     healthcheck:
-        test: ["CMD", "wget", "--no-verbose", "--spider",  "http://localhost:7700/health"]
+        test: ["CMD", "wget", "--no-verbose", "--spider",  "http://127.0.0.1:7700/health"]
         retries: 3
         timeout: 5s


### PR DESCRIPTION
When using `vendor/bin/sail up` it mails as meilisearch container does not pass the healthcheck.
It wget's to localhost ::1 and not the IPv4 Address, so the check fails with:
`Connecting to localhost:7700 ([::1]:7700)
wget: can't connect to remote host: Connection refused`

This fixes the issue, using 127.0.0.1 as IPv4.