### PR TITLE
add chokidar support

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -60,6 +60,7 @@ COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
+RUN npm install --save-dev chokidar
 
 EXPOSE 8000
 


### PR DESCRIPTION
The document says we can run php artisan octane:start --watch, so adding --watch support is a must.