### PR TITLE
Feature: add support for phpmyadmin

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -25,6 +25,7 @@ trait InteractsWithDockerComposeServices
         'mailpit',
         'selenium',
         'soketi',
+        'phpmyadmin'
     ];
 
     /**

--- a/stubs/phpmyadmin.stub
+++ b/stubs/phpmyadmin.stub
@@ -1,0 +1,11 @@
+pma:
+    image: phpmyadmin/phpmyadmin
+    ports:
+        - 8080:80
+    environment:
+        PMA_HOST: mysql
+        MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
+    depends_on:
+        - mysql
+    networks:
+        - sail

--- a/stubs/phpmyadmin.stub
+++ b/stubs/phpmyadmin.stub
@@ -1,4 +1,4 @@
-pma:
+phpmyadmin:
     image: phpmyadmin/phpmyadmin
     ports:
         - 8080:80


### PR DESCRIPTION
This pull request proposes the addition of [phpMyAdmin](https://www.phpmyadmin.net) to Laravel Sail.

To achieve this, `stubs/phpmyadmin.stub` has been created which contains a standard implementation that will work out of the box assuming mysql has been selected.

Additionally, `InteractsWithDockerComposeServices` has been modified to add `phpmyadmin` to the protected `$services` array.

Currently, at work, we add phpMyAdmin manually to every project using Laravel Sail - and have long wondered if it was something that belongs within the installer. The benefit of this to end users is essentially in time; by having it installed out of the box, we remove the need to revisit old projects to find an old `pma` entry.

The obvious critique is that a new user may not realise that phpMyAdmin won't work with, say, MariaDB out of the box. I suspect checking for this and modifying the stub as required wouldn't be too complicated, but wanted to at least check in here before I go to that length!