### PR TITLE
[1.x] Use Official MariaDB Healthcheck Script

### DIFF
--- a/stubs/mariadb10.stub
+++ b/stubs/mariadb10.stub
@@ -15,6 +15,6 @@ mariadb:
     networks:
         - sail
     healthcheck:
-        test: ["CMD", "mariadb-admin", "ping", "-p${DB_PASSWORD}"]
+        test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
         retries: 3
         timeout: 5s

--- a/stubs/mariadb11.stub
+++ b/stubs/mariadb11.stub
@@ -15,6 +15,6 @@ mariadb:
     networks:
         - sail
     healthcheck:
-        test: ["CMD", "mariadb-admin", "ping", "-p${DB_PASSWORD}"]
+        test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
         retries: 3
         timeout: 5s


### PR DESCRIPTION
This pull request updates the health check command for the MariaDB service in the configuration to utilize the `healthcheck.sh` script provided by MariaDB, as recommended in the [official documentation](https://mariadb.com/kb/en/using-healthcheck-sh/).

Key Improvements:
 - The new health check script checks connectivity and ensures that InnoDB is initialized.
 - By using `healthcheck.sh`, there is no need to provide the database password, enhancing security by avoiding exposure of credentials.

The script leverages the health check user and is designed specifically for this purpose.