### PR TITLE
Update EXPOSE port command

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -61,6 +61,5 @@ COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp
-EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -60,6 +60,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
+EXPOSE 80/tcp
 EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -60,6 +60,5 @@ COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp
-EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -59,6 +59,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
+EXPOSE 80/tcp
 EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -61,6 +61,5 @@ COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp
-EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -60,6 +60,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
+EXPOSE 80/tcp
 EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -62,6 +62,5 @@ COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp
-EXPOSE 8000
 
 ENTRYPOINT ["start-container"]

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -61,6 +61,7 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
 RUN chmod +x /usr/local/bin/start-container
 
+EXPOSE 80/tcp
 EXPOSE 8000
 
 ENTRYPOINT ["start-container"]


### PR DESCRIPTION
The Dockerfile currently exposes port 80 by default using the following command:

```bash
SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
```

It's important to note that the `EXPOSE` command in Docker does not actively publish ports; rather, it serves as a declaration for applications like `traefik` to discover which ports are intended to be exposed by the container.

Commit 33a723fa73b7dc66797f343e8cab372ee5531559 removes the `8080` port, as it was not being utilized by any service by default. Feel free to revert this commit if you prefer to maintain the previous port configuration.

I am open to updating the port from `EXPOSE 80/tcp` to `EXPOSE 80` if you would rather the existing format

Thank you for your attention to this matter.
