### PR TITLE
fix: fixed swoole extension that gets the SQLSTATE[08006] error

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update \
        php8.3-msgpack php8.3-igbinary php8.3-redis \
        php8.3-memcached php8.3-pcov php8.3-imagick php8.3-xdebug \
        && pecl install swoole-5.1.2 \
+       && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/20-swoole.ini
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -29,8 +29,9 @@ RUN apt-get update \
        php8.3-xml php8.3-zip php8.3-bcmath php8.3-soap \
        php8.3-intl php8.3-readline \
        php8.3-ldap \
-       php8.3-msgpack php8.3-igbinary php8.3-redis php8.3-swoole \
+       php8.3-msgpack php8.3-igbinary php8.3-redis \
        php8.3-memcached php8.3-pcov php8.3-imagick php8.3-xdebug \
+       && pecl install swoole-5.1.2 \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
## Description

While working on my server, I encountered the error` SQLSTATE[08006]`, which is caused by the Swoole extension installed through the PPA. To resolve this issue, I reinstalled Swoole using PECL, which resolved the connection problem. 

My reference to solve the problem: https://stackoverflow.com/questions/78669556/possible-bug-with-php-pdo-and-with-postgresql

![image](https://github.com/user-attachments/assets/0ec87426-bc12-4be3-a8cc-1effee7de73c)
