### PR TITLE
[1.x] Adds Microsoft SQL Server

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -83,6 +83,7 @@ function display_help {
     echo "  ${GREEN}sail mysql${NC}     Start a MySQL CLI session within the 'mysql' container"
     echo "  ${GREEN}sail mariadb${NC}   Start a MySQL CLI session within the 'mariadb' container"
     echo "  ${GREEN}sail psql${NC}      Start a PostgreSQL CLI session within the 'pgsql' container"
+    echo "  ${GREEN}sail sqlsrv${NC}    Start a Microsoft SQL Server CLI session within the 'sqlsrv' container"
     echo "  ${GREEN}sail redis${NC}     Start a Redis CLI session within the 'redis' container"
     echo
     echo "${YELLOW}Debugging:${NC}"
@@ -496,6 +497,19 @@ elif [ "$1" == "psql" ]; then
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(pgsql bash -c)
         ARGS+=("PGPASSWORD=\${PGPASSWORD} psql -U \${POSTGRES_USER} \${POSTGRES_DB}")
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a Microsoft SQL Server CLI terminal session within the "sqlsrv" container...
+elif [ "$1" == "sqlsrv" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(sqlcmd bash -c)
+        ARGS+=("sqlcmd -No -d \${MSSQL_DB_NAME} -P \${MSSQL_PASSWORD} -U \${MSSQL_USER}")
     else
         sail_is_not_running
     fi

--- a/database/sqlsrv/entrypoint.sh
+++ b/database/sqlsrv/entrypoint.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# If there is a command, execute it.
+if [ "$#" -ne 0 ]; then
+    exec "$@"
+fi
+
+SQLCMD="/opt/mssql-tools/bin/sqlcmd"
+
+if [ -f /opt/mssql-tools18/bin/sqlcmd ]; then
+    SQLCMD="/opt/mssql-tools18/bin/sqlcmd"
+fi
+
+echo "$(date '+%Y-%m-%d %H:%M:%S.%2N') sail        Starting Microsoft SQL Server for init scripts."
+
+# Start SQL Server
+/opt/mssql/bin/sqlservr -mSQLCMD -f -c -x &
+
+# Function to check if SQL Server is ready
+sql_server_is_ready() {
+    $SQLCMD -No -U sa -P "${MSSQL_SA_PASSWORD}" -Q "SELECT 1" &> /dev/null
+    return $?
+}
+
+# Wait for SQL Server to start
+sleep 3
+
+# Wait until SQL Server is ready
+until sql_server_is_ready; do
+    echo "$(date '+%Y-%m-%d %H:%M:%S.%2N') sail        Waiting for SQL Server to be available..."
+    sleep 1
+done
+
+SQL_INIT=$(cat <<-EOSQL
+    IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = "$MSSQL_DB_NAME") BEGIN
+        CREATE DATABASE $MSSQL_DB_NAME;
+    END
+    GO
+
+    IF NOT EXISTS (SELECT name FROM master.sys.server_principals WHERE name = "$MSSQL_USER") BEGIN
+        CREATE LOGIN $MSSQL_USER WITH
+            PASSWORD = "$MSSQL_PASSWORD",
+            DEFAULT_DATABASE = $MSSQL_DB_NAME,
+            CHECK_EXPIRATION = OFF,
+            CHECK_POLICY = OFF;
+    END
+    GO
+
+    IF NOT EXISTS(SELECT * FROM sys.database_principals WHERE name = "$MSSQL_USER") BEGIN
+        CREATE USER $MSSQL_USER FOR LOGIN $MSSQL_USER;
+        ALTER ROLE db_owner ADD MEMBER $MSSQL_USER;
+    END
+    GO
+EOSQL
+)
+
+echo "$(date '+%Y-%m-%d %H:%M:%S.%2N') sail        Initializing ${MSSQL_DB_NAME} database for ${MSSQL_USER}."
+
+## Set the engine default user and database name
+$SQLCMD -No -U sa -No -P "${MSSQL_SA_PASSWORD}" -Q "${SQL_INIT}"
+
+SQL_INIT_TESTING=$(cat <<-EOSQL
+    IF NOT EXISTS(SELECT * FROM sys.databases WHERE name = "testing") BEGIN
+        CREATE DATABASE testing;
+    END
+    GO
+
+    IF NOT EXISTS(SELECT * FROM sys.database_principals WHERE name = "testing") BEGIN
+        CREATE USER testing FOR LOGIN testing WITH
+          PASSWORD = "",
+          DEFAULT_DATABASE = "testing",
+          CHECK_EXPIRATION = OFF,
+          CHECK_POLICY = OFF;
+        ALTER ROLE db_datareader ADD MEMBER testing;
+        ALTER ROLE db_datawriter ADD MEMBER testing;
+        ALTER ROLE db_ddladmin ADD MEMBER testing;
+    END
+    GO
+EOSQL
+)
+
+echo "$(date '+%Y-%m-%d %H:%M:%S.%2N') sail        Initializing testing database."
+
+## Create the testing database if it doesn't exists
+$SQLCMD -No -U sa -P "${MSSQL_SA_PASSWORD}" -Q "${SQL_INIT_TESTING}"
+
+echo "$(date '+%Y-%m-%d %H:%M:%S.%2N') sail        Restarting Microsoft SQL Server after init scripts."
+echo ""
+echo "---"
+echo ""
+
+# Kill the server
+pkill sqlservr
+
+# Start it again.
+exec /opt/mssql/bin/sqlservr

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="Taylor Otwell"
 ARG WWWGROUP
 ARG NODE_VERSION=20
 ARG POSTGRES_VERSION=13
+ARG SQLSRV_VERSION=5.11.1
+ARG ACCEPT_EULA="N"
 
 WORKDIR /var/www/html
 
@@ -47,6 +49,22 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ "$ACCEPT_EULA" = "Y" ]; then \
+         curl -sS https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+      && curl -sS https://packages.microsoft.com/config/ubuntu/20.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+      && apt-get update \
+      && apt-get install -y mssql-tools18 unixodbc-dev \
+      && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
+      && pecl install sqlsrv pdo_sqlsrv-$SQLSRV_VERSION \
+      && printf "; priority=20\nextension=sqlsrv.so\n" > /etc/php/8.0/mods-available/sqlsrv.ini \
+      && printf "; priority=30\nextension=pdo_sqlsrv.so\n" > /etc/php/8.0/mods-available/pdo_sqlsrv.ini \
+      && phpenmod sqlsrv pdo_sqlsrv \
+      && bash -c "source ~/.bashrc" \
+      && apt-get -y autoremove \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    fi
 
 RUN update-alternatives --set php /usr/bin/php8.0
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="Taylor Otwell"
 ARG WWWGROUP
 ARG NODE_VERSION=20
 ARG POSTGRES_VERSION=15
+ARG SQLSRV_VERSION=5.12.0
+ARG ACCEPT_EULA="N"
 
 WORKDIR /var/www/html
 
@@ -48,6 +50,22 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ "$ACCEPT_EULA" = "Y" ]; then \
+         curl -sS https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+      && curl -sS https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+      && apt-get update \
+      && apt-get install -y mssql-tools18 unixodbc-dev \
+      && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
+      && pecl install sqlsrv pdo_sqlsrv-$SQLSRV_VERSION \
+      && printf "; priority=20\nextension=sqlsrv.so\n" > /etc/php/8.1/mods-available/sqlsrv.ini \
+      && printf "; priority=30\nextension=pdo_sqlsrv.so\n" > /etc/php/8.1/mods-available/pdo_sqlsrv.ini \
+      && phpenmod sqlsrv pdo_sqlsrv \
+      && bash -c "source ~/.bashrc" \
+      && apt-get -y autoremove \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -5,6 +5,8 @@ LABEL maintainer="Taylor Otwell"
 ARG WWWGROUP
 ARG NODE_VERSION=20
 ARG POSTGRES_VERSION=15
+ARG SQLSRV_VERSION=5.12.0
+ARG ACCEPT_EULA="N"
 
 WORKDIR /var/www/html
 
@@ -49,6 +51,22 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ "$ACCEPT_EULA" = "Y" ]; then \
+         curl -sS https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+      && curl -sS https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+      && apt-get update \
+      && apt-get install -y mssql-tools18 unixodbc-dev \
+      && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
+      && pecl install sqlsrv pdo_sqlsrv-$SQLSRV_VERSION \
+      && printf "; priority=20\nextension=sqlsrv.so\n" > /etc/php/8.2/mods-available/sqlsrv.ini \
+      && printf "; priority=30\nextension=pdo_sqlsrv.so\n" > /etc/php/8.2/mods-available/pdo_sqlsrv.ini \
+      && phpenmod sqlsrv pdo_sqlsrv \
+      && bash -c "source ~/.bashrc" \
+      && apt-get -y autoremove \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -6,6 +6,8 @@ ARG WWWGROUP
 ARG NODE_VERSION=20
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=15
+ARG SQLSRV_VERSION=5.12.0
+ARG ACCEPT_EULA="N"
 
 WORKDIR /var/www/html
 
@@ -50,6 +52,22 @@ RUN apt-get update \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ "$ACCEPT_EULA" = "Y" ]; then \
+         curl -sS https://packages.microsoft.com/keys/microsoft.asc | tee /etc/apt/trusted.gpg.d/microsoft.asc \
+      && curl -sS https://packages.microsoft.com/config/ubuntu/22.04/prod.list | tee /etc/apt/sources.list.d/mssql-release.list \
+      && apt-get update \
+      && apt-get install -y mssql-tools18 unixodbc-dev \
+      && echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc \
+      && pecl install sqlsrv pdo_sqlsrv-$SQLSRV_VERSION \
+      && printf "; priority=20\nextension=sqlsrv.so\n" > /etc/php/8.3/mods-available/sqlsrv.ini \
+      && printf "; priority=30\nextension=pdo_sqlsrv.so\n" > /etc/php/8.3/mods-available/pdo_sqlsrv.ini \
+      && phpenmod sqlsrv pdo_sqlsrv \
+      && bash -c "source ~/.bashrc" \
+      && apt-get -y autoremove \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+    fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -41,7 +41,8 @@ class PublishCommand extends Command
                     './vendor/laravel/sail/runtimes/8.1',
                     './vendor/laravel/sail/runtimes/8.0',
                     './vendor/laravel/sail/database/mysql',
-                    './vendor/laravel/sail/database/pgsql'
+                    './vendor/laravel/sail/database/pgsql',
+                    './vendor/laravel/sail/database/sqlsrv',
                 ],
                 [
                     './docker/8.3',
@@ -49,7 +50,8 @@ class PublishCommand extends Command
                     './docker/8.1',
                     './docker/8.0',
                     './docker/mysql',
-                    './docker/pgsql'
+                    './docker/pgsql',
+                    './docker/sqlsrv',
                 ],
                 file_get_contents($this->laravel->basePath('docker-compose.yml'))
             )

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -6,6 +6,7 @@ services:
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
+                ACCEPT_EULA: '${ACCEPT_EULA}'
         image: sail-8.3/app
         extra_hosts:
             - 'host.docker.internal:host-gateway'

--- a/stubs/sqlsrv.stub
+++ b/stubs/sqlsrv.stub
@@ -1,0 +1,20 @@
+sqlsrv:
+    image: 'mcr.microsoft.com/mssql/server:2022-latest'
+    ports:
+        - '${FORWARD_DB_PORT:-1433}:1433'
+    environment:
+        MSSQL_DB_NAME: '${DB_DATABASE}'
+        MSSQL_USER: '${DB_USERNAME}'
+        MSSQL_SA_PASSWORD: '${DB_ROOT_PASSWORD}'
+        MSSQL_PASSWORD: '${DB_PASSWORD}'
+        ACCEPT_EULA: '${ACCEPT_EULA}'
+    volumes:
+        - 'sail-sqlsrv:/var/opt/mssql'
+        - './vendor/laravel/sail/database/sqlsrv/entrypoint.sh:/entrypoint.sh'
+    entrypoint: '/entrypoint.sh'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "timeout", "1", "bash", "-c", "cat < /dev/null > /dev/tcp/127.0.0.1/1433"]
+        timeout: 5s
+        retries: 3


### PR DESCRIPTION
# What? 

This brings Microsoft SQL Server (their latest version) to Sail. I did it because I usually deal with clients using Azure ootb, and MSSQL it's very picky.

Because the Docker Container is very non-standard, the whole setup is done by setting a custom entrypoint. If no command is issued, the script _initializes_ the databases (default and testing) and then starts SQL Server again but through `exec`.

## EULA shenanigans

The installation is done by manually accepting Microsoft SQL Server EULA, which is found on their [Docker Hub](https://hub.docker.com/r/microsoft/mssql-server). This is both required to install the database engine and the PHP extensions to connect. If the EULA is not accepted, the installation fails.

This sounds like a hurdle, but the correct thing to do is let the developer accept the EULA.

## What adds and changes

- Adds `sqlsrv` service.
- Adds the `DB_ROOT_PASWORD` with a _complex_ password (required by SQL Server)
- All Dockerfile have an additional block to install `sqlsrv` and `pdo_sqlsrv` only if the EULA is accepted (by default, nope).
- Extensions version are _fixed_. This is because latest versions drop support for old PHP versions.

## Pending work

- The Sail Server (laravel.build) should add `slqsrv` to the accepted services array.
- The documentation (laravel.com/docs/sail) should mention `sqlsrv` support with the following caveats:
  - Microsoft SQL Server is a x64-only container.
  - Requires EULA Acceptance
  - Adds a separate "root" strong password due to default SQL Server policies.