### PR TITLE
fix: missing \ in dockerfile 8.3

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update \
        php8.3-msgpack php8.3-igbinary php8.3-redis \
        php8.3-memcached php8.3-pcov php8.3-imagick php8.3-xdebug \
        && pecl install swoole-5.1.2 \
-       && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/20-swoole.ini
+       && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/20-swoole.ini \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
In commit #715 a change was made that removed the \ at the end of the command 'echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/20-swoole.ini'. It was added back because it was breaking the image build!
