### PR TITLE
[1.x] Add Docker Compose Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,9 @@ jobs:
         working-directory: app
 
       - name: Install Sail into App
-        run: php artisan sail:install --php=${{ matrix.php }} --no-interaction
+        run: |
+          php artisan sail:install --php=${{ matrix.php }} --no-interaction
+          php artisan sail:publish --no-interaction
         working-directory: app
 
       - name: Remove Sail
@@ -69,6 +71,10 @@ jobs:
 
       - name: Output .env
         run: cat .env
+        working-directory: app
+
+      - name: Output docker-compose.yml
+        run: cat docker-compose.yml
         working-directory: app
 
       - name: Run Migrations

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,14 +69,6 @@ jobs:
         run: ../sail/bin/sail up -d --wait
         working-directory: app
 
-      - name: Output .env
-        run: cat .env
-        working-directory: app
-
-      - name: Output docker-compose.yml
-        run: cat docker-compose.yml
-        working-directory: app
-
       - name: Run Migrations
         run: ../sail/bin/sail artisan migrate --no-interaction
         working-directory: app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           coverage: none
 
       - name: Create a new laravel application
-        uses: composer create-project laravel/laravel app "${{ matrix.laravel }}.x" --remove-vsc --no-interaction --prefer-dist
+        run: composer create-project laravel/laravel app "${{ matrix.laravel }}.x" --remove-vsc --no-interaction --prefer-dist
 
       - name: Link Sail Repository
         run: |
@@ -55,7 +55,11 @@ jobs:
           composer require laravel/sail:* --dev -W
         working-directory: app
 
-      - name: Start Sail Container (In Background)
+      - name: Install Sail into App
+        run: php artisan sail:install --no-interaction
+        working-directory: app
+
+      - name: Build and Start Sail Container
         run: vendor/bin/sail up -d
         working-directory: app
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,14 +59,22 @@ jobs:
         run: php artisan sail:install --php=${{ matrix.php }} --no-interaction
         working-directory: app
 
-      - name: Build and Start Sail Container
-        run: vendor/bin/sail up -d
+      - name: Remove Sail
+        run: composer remove laravel/sail --no-interaction
+        working-directory: app
+
+      - name: Start Sail Container
+        run: ../sail/bin/sail up -d
+        working-directory: app
+
+      - name: Run Migrations
+        run: ../sail/bin/sail artisan migrate --no-interaction
         working-directory: app
 
       - name: Run Tests in Sail Container
-        run: vendor/bin/sail test
+        run: ../sail/bin/sail test
         working-directory: app
 
       - name: Stop Sail Container
-        run: vendor/bin/sail down
+        run: ../sail/bin/sail down
         working-directory: app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,7 +66,7 @@ jobs:
         working-directory: app
 
       - name: Start Sail Container
-        run: ../sail/bin/sail up -d
+        run: ../sail/bin/sail up -d --wait
         working-directory: app
 
       - name: Output .env

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,10 @@ jobs:
         run: ../sail/bin/sail up -d
         working-directory: app
 
+      - name: Output .env
+        run: cat .env
+        working-directory: app
+
       - name: Run Migrations
         run: ../sail/bin/sail artisan migrate --no-interaction
         working-directory: app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
           coverage: none
 
       - name: Create a new laravel application
-        run: composer create-project laravel/laravel app "${{ matrix.laravel }}.x" --remove-vsc --no-interaction --prefer-dist
+        run: composer create-project laravel/laravel app "${{ matrix.laravel }}.x" --remove-vcs --no-interaction --prefer-dist
 
       - name: Link Sail Repository
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,7 +56,7 @@ jobs:
         working-directory: app
 
       - name: Install Sail into App
-        run: php artisan sail:install --no-interaction
+        run: php artisan sail:install --php=${{ matrix.php }} --no-interaction
         working-directory: app
 
       - name: Build and Start Sail Container

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: app
 
       - name: Remove Sail
-        run: composer remove laravel/sail --no-interaction
+        run: composer remove laravel/sail --dev --no-interaction -W
         working-directory: app
 
       - name: Start Sail Container

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,68 @@
+name: Docker Compose Test
+
+on:
+  push:
+    branches:
+      - master
+      - '*.x'
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - php: '8.0'
+            laravel: 10
+          - php: '8.1'
+            laravel: 10
+          - php: '8.2'
+            laravel: 11
+          - php: '8.3'
+            laravel: 11
+
+    name: PHP ${{ matrix.php }} - L${{ matrix.laravel }}
+
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: 'sail'
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo
+          ini-values: error_reporting=E_ALL
+          tools: composer:v2
+          coverage: none
+
+      - name: Create a new laravel application
+        uses: composer create-project laravel/laravel app "${{ matrix.laravel }}.x" --remove-vsc --no-interaction --prefer-dist
+
+      - name: Link Sail Repository
+        run: |
+          composer config minimum-stability dev
+          composer config repositories.sail path ../sail
+          composer require laravel/sail:* --dev -W
+        working-directory: app
+
+      - name: Start Sail Container (In Background)
+        run: vendor/bin/sail up -d
+        working-directory: app
+
+      - name: Run Tests in Sail Container
+        run: vendor/bin/sail test
+        working-directory: app
+
+      - name: Stop Sail Container
+        run: vendor/bin/sail down
+        working-directory: app

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         include:
           - php: '8.0'
-            laravel: 10
+            laravel: 9
           - php: '8.1'
             laravel: 10
           - php: '8.2'

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -116,7 +116,11 @@ trait InteractsWithDockerComposeServices
             $compose['services']['selenium']['image'] = 'seleniarm/standalone-chromium';
         }
 
-        file_put_contents($this->laravel->basePath('docker-compose.yml'), Yaml::dump($compose, Yaml::DUMP_OBJECT_AS_MAP));
+        $yaml = Yaml::dump($compose, Yaml::DUMP_OBJECT_AS_MAP);
+
+        $yaml = str_replace('{{PHP_VERSION}}', $this->option('php'), $yaml);
+
+        file_put_contents($this->laravel->basePath('docker-compose.yml'), $yaml);
     }
 
     /**

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -19,7 +19,8 @@ class InstallCommand extends Command
      */
     protected $signature = 'sail:install
                 {--with= : The services that should be included in the installation}
-                {--devcontainer : Create a .devcontainer configuration directory}';
+                {--devcontainer : Create a .devcontainer configuration directory}
+                {--php=8.3 : The PHP version that should be used}';
 
     /**
      * The console command description.

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -2,11 +2,11 @@
 services:
     laravel.test:
         build:
-            context: ./vendor/laravel/sail/runtimes/8.3
+            context: ./vendor/laravel/sail/runtimes/{{PHP_VERSION}}
             dockerfile: Dockerfile
             args:
                 WWWGROUP: '${WWWGROUP}'
-        image: sail-8.3/app
+        image: sail-{{PHP_VERSION}}/app
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:


### PR DESCRIPTION
This PR adds a test workflow for building all Sail PHP-Versions. For this I also added the ability to choose the PHP-Version in the sail:install command.

The reason for the PR is the breakage, which sometimes have happened after some Pull Requests with not enough testing. (Like just a day ago)