### PR TITLE
Use selenium/standalone-chromium on AMD and ARM

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -104,11 +104,6 @@ trait InteractsWithDockerComposeServices
             unset($compose['volumes']);
         }
 
-        // Replace Selenium with ARM base container on Apple Silicon...
-        if (in_array('selenium', $services) && in_array(php_uname('m'), ['arm64', 'aarch64'])) {
-            $compose['services']['selenium']['image'] = 'selenium/standalone-chromium';
-        }
-
         $yaml = Yaml::dump($compose, Yaml::DUMP_OBJECT_AS_MAP);
 
         $yaml = str_replace('{{PHP_VERSION}}', $this->option('php'), $yaml);

--- a/stubs/selenium.stub
+++ b/stubs/selenium.stub
@@ -1,5 +1,5 @@
 selenium:
-    image: 'selenium/standalone-chrome'
+    image: 'selenium/standalone-chromium'
     extra_hosts:
         - 'host.docker.internal:host-gateway'
     volumes:


### PR DESCRIPTION
This PR unifies the use to `selenium/standalone-chromium` on both AMD and ARM, instead of before the two different images:
- `selenium/standalone-chrome` for AMD
- `selenium/standalone-chromium` for ARM

What currently happens: If you are on AMD-based platform the first image will be used, if you are on an ARM-based platform the second-image will be used.

If a team has different platforms, this can result in a conflict. Therefor I would recommend using the standalone-chromium image, which supports both platforms.
