### PR TITLE
Use selenium/standalone-chromium on ARM

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -113,7 +113,7 @@ trait InteractsWithDockerComposeServices
 
         // Replace Selenium with ARM base container on Apple Silicon...
         if (in_array('selenium', $services) && in_array(php_uname('m'), ['arm64', 'aarch64'])) {
-            $compose['services']['selenium']['image'] = 'seleniarm/standalone-chromium';
+            $compose['services']['selenium']['image'] = 'selenium/standalone-chromium';
         }
 
         $yaml = Yaml::dump($compose, Yaml::DUMP_OBJECT_AS_MAP);


### PR DESCRIPTION
> [!NOTE]
> There are two possible PR: This one here which only modifies the ARM image, or https://github.com/laravel/sail/pull/722 which unifies the chromium image for both AMD and ARM.
> I would be more in favour of the other PR https://github.com/laravel/sail/pull/722, because in a multi person team, it causes less disruptions if different platforms are used.

Based on the PR https://github.com/laravel/docs/pull/9875 I replaced the image which will be used on ARM, without touching the AMD part.

Description of the PR https://github.com/laravel/docs/pull/9875:
> This PR changes the recommended image for Sail's Selenium service on Apple Silicon from seleniarm/standalone-chromium to selenium/standalone-chromium. Notice selenium instead of seleniarm 😄

> Reason: The community-maintained fork was merged back into the official Selenium project in May 2024 and is now only maintained there. See the [official announcement](https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/) by the Selenium project. The [latest seleniarm/standalone-chromium release](https://hub.docker.com/r/seleniarm/standalone-chromium/tags) is Chromium v124.0.6367.78 from four months ago. Its [GitHub repository is now archived](https://github.com/seleniumhq-community/docker-seleniarm). Unfortunately, until [Google provides Linux/ARM builds for Chrome](https://www.selenium.dev/blog/2024/multi-arch-images-via-docker-selenium/#browser-binaries), Apple Silicon / ARM users still need to switch from Chrome to Chromium.