### PR TITLE
Cleanup unneeded code

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -81,13 +81,6 @@ trait InteractsWithDockerComposeServices
                 ->all();
         }
 
-        // Update the dependencies if the MariaDB service is used...
-        if (in_array('mariadb', $services)) {
-            $compose['services']['laravel.test']['depends_on'] = array_map(function ($dependedItem) {
-                return $dependedItem;
-            }, $compose['services']['laravel.test']['depends_on']);
-        }
-
         // Add the services to the docker-compose.yml...
         collect($services)
             ->filter(function ($service) use ($compose) {


### PR DESCRIPTION
Seems like I missed a little code snippet during the revert to only support MariaDB 11 in https://github.com/laravel/sail/pull/707