### PR TITLE
add startretries=1000 to supervisor.config file

### DIFF
--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -12,3 +12,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+startretries=1000

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -12,3 +12,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+startretries=1000

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -12,3 +12,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+startretries=1000

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -12,3 +12,4 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+startretries=1000


### PR DESCRIPTION
When we use the `--watch` flag if the code contains a syntax error the PHP program are going to fail and by default, if the program doesn't start after 3 restarts we are getting this error:
```
 INFO exited: PHP (exit status 1; not expected)
 INFO gave up: php entered the FATAL state, too many start retries too quickly
```
The supervisor will not try to boot the server again. 
And that's super annoying, especially in octane. 
We need to restart the docker-compose to boot the octane server.
By adding `startretries=1000` it will try to start the server 1000 times instead of 3 times.
And it fixes the problem. 
