### PR TITLE
Disable global `defer()` in Swoole, via `swoole.use_shortname`

### DIFF
--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname = off

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname = off

--- a/runtimes/8.2/php.ini
+++ b/runtimes/8.2/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname = off

--- a/runtimes/8.3/php.ini
+++ b/runtimes/8.3/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname = off


### PR DESCRIPTION
Fixes https://github.com/laravel/octane/issues/948 (accidentally created the issue on the wrong Repo - don't know how that happened)