### PR TITLE
Pass all command line arguments to wrapped executable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -212,7 +212,7 @@ if [ "$1" == "php" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" "php" "$@")
+        ARGS+=("$APP_SERVICE" "php")
     else
         sail_is_not_running
     fi
@@ -222,9 +222,11 @@ elif [ "$1" == "bin" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
+        CMD=$1
+        shift 1
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" ./vendor/bin/"$@")
+        ARGS+=("$APP_SERVICE" ./vendor/bin/"$CMD")
     else
         sail_is_not_running
     fi
@@ -248,7 +250,7 @@ elif [ "$1" == "composer" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" "composer" "$@")
+        ARGS+=("$APP_SERVICE" "composer")
     else
         sail_is_not_running
     fi
@@ -260,7 +262,7 @@ elif [ "$1" == "artisan" ] || [ "$1" == "art" ] || [ "$1" == "a" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php artisan "$@")
+        ARGS+=("$APP_SERVICE" php artisan)
     else
         sail_is_not_running
     fi
@@ -272,7 +274,7 @@ elif [ "$1" == "debug" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail -e XDEBUG_TRIGGER=1)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php artisan "$@")
+        ARGS+=("$APP_SERVICE" php artisan)
     else
         sail_is_not_running
     fi
@@ -284,7 +286,7 @@ elif [ "$1" == "test" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php artisan test "$@")
+        ARGS+=("$APP_SERVICE" php artisan test)
     else
         sail_is_not_running
     fi
@@ -296,7 +298,7 @@ elif [ "$1" == "phpunit" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/phpunit "$@")
+        ARGS+=("$APP_SERVICE" php vendor/bin/phpunit)
     else
         sail_is_not_running
     fi
@@ -308,7 +310,7 @@ elif [ "$1" == "pest" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/pest "$@")
+        ARGS+=("$APP_SERVICE" php vendor/bin/pest)
     else
         sail_is_not_running
     fi
@@ -320,7 +322,7 @@ elif [ "$1" == "pint" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/pint "$@")
+        ARGS+=("$APP_SERVICE" php vendor/bin/pint)
     else
         sail_is_not_running
     fi
@@ -334,7 +336,7 @@ elif [ "$1" == "dusk" ]; then
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
-        ARGS+=("$APP_SERVICE" php artisan dusk "$@")
+        ARGS+=("$APP_SERVICE" php artisan dusk)
     else
         sail_is_not_running
     fi
@@ -348,13 +350,13 @@ elif [ "$1" == "dusk:fails" ]; then
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
-        ARGS+=("$APP_SERVICE" php artisan dusk:fails "$@")
+        ARGS+=("$APP_SERVICE" php artisan dusk:fails)
     else
         sail_is_not_running
     fi
 
 # Initiate a Laravel Tinker session within the application container...
-elif [ "$1" == "tinker" ] ; then
+elif [ "$1" == "tinker" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
@@ -372,7 +374,7 @@ elif [ "$1" == "node" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" node "$@")
+        ARGS+=("$APP_SERVICE" node)
     else
         sail_is_not_running
     fi
@@ -384,7 +386,7 @@ elif [ "$1" == "npm" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" npm "$@")
+        ARGS+=("$APP_SERVICE" npm)
     else
         sail_is_not_running
     fi
@@ -396,7 +398,7 @@ elif [ "$1" == "npx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" npx "$@")
+        ARGS+=("$APP_SERVICE" npx)
     else
         sail_is_not_running
     fi
@@ -408,7 +410,7 @@ elif [ "$1" == "pnpm" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" pnpm "$@")
+        ARGS+=("$APP_SERVICE" pnpm)
     else
         sail_is_not_running
     fi
@@ -420,7 +422,7 @@ elif [ "$1" == "pnpx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" pnpx "$@")
+        ARGS+=("$APP_SERVICE" pnpx)
     else
         sail_is_not_running
     fi
@@ -432,7 +434,7 @@ elif [ "$1" == "yarn" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" yarn "$@")
+        ARGS+=("$APP_SERVICE" yarn)
     else
         sail_is_not_running
     fi
@@ -444,7 +446,7 @@ elif [ "$1" == "bun" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bun "$@")
+        ARGS+=("$APP_SERVICE" bun)
     else
         sail_is_not_running
     fi
@@ -456,7 +458,7 @@ elif [ "$1" == "bunx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bunx "$@")
+        ARGS+=("$APP_SERVICE" bunx)
     else
         sail_is_not_running
     fi
@@ -507,7 +509,7 @@ elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bash "$@")
+        ARGS+=("$APP_SERVICE" bash)
     else
         sail_is_not_running
     fi
@@ -519,13 +521,13 @@ elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u root)
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" bash "$@")
+        ARGS+=("$APP_SERVICE" bash)
     else
         sail_is_not_running
     fi
 
 # Initiate a Redis CLI terminal session within the "redis" container...
-elif [ "$1" == "redis" ] ; then
+elif [ "$1" == "redis" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
@@ -573,11 +575,7 @@ elif [ "$1" == "open" ]; then
     else
         sail_is_not_running
     fi
-
-# Pass unknown commands to the "docker-compose" binary...
-else
-    ARGS+=("$@")
 fi
 
 # Run Docker Compose with the defined arguments...
-"${DOCKER_COMPOSE[@]}" "${ARGS[@]}"
+"${DOCKER_COMPOSE[@]}" "${ARGS[@]}" "$@"


### PR DESCRIPTION
This PR makes `sail <command> <args>` always pass `<args>` to `<command>`.

#### Motivation

I found some discrepancies when using the `tinker` subcommand:

- `artisan tinker -h` shows tinker's help
- `sail tinker -h` directly enters the REPL

More specifically, my use case was to load a file that takes care of performing some initialization for me. Setting the current user, maybe assigning some variables that I'll need while testing things. But that doesn't work either:

```bash
echo '<?php throw new \Exception("File loaded");' > init.php

$ artisan tinker init.php
Psy Shell v0.12.3 (PHP 8.3.10 — cli) by Justin Hileman

   Exception  File loaded.

>

$ sail tinker init.php
Psy Shell v0.12.3 (PHP 8.3.10 — cli) by Justin Hileman
>
```

----

When looking at the `sail` script, I noticed that _most_ commands forward `$@`, but `tinker`, `mysql`, `mariadb`, `psql`, `redis`, and `open` don't.

I believe this is confusing behavior, as it makes sail differ from how the actual underlying program works (like the tinker example). If a user passes an extra argument they probably do it for a reason, so with this change every argument is passed as-is.