### PR TITLE
Fix missing php option when trying to run sail:add

### DIFF
--- a/src/Console/AddCommand.php
+++ b/src/Console/AddCommand.php
@@ -18,6 +18,7 @@ class AddCommand extends Command
      */
     protected $signature = 'sail:add
         {services? : The services that should be added}
+        {--php=8.3 : The PHP version that should be used}
     ';
 
     /**


### PR DESCRIPTION
Fixes #729 

This just introduces a --php option to mirror sail:install with the same default of PHP 8.3, open to suggestions for alternative ways to fix this, but this seemed like the most logical and straightforward solution.
