### PR TITLE
Use apt php8.3-swoole again

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -30,9 +30,7 @@ RUN apt-get update \
        php8.3-intl php8.3-readline \
        php8.3-ldap \
        php8.3-msgpack php8.3-igbinary php8.3-redis \
-       php8.3-memcached php8.3-pcov php8.3-imagick php8.3-xdebug \
-       && pecl install swoole-5.1.2 \
-       && echo "extension=swoole.so" > /etc/php/8.3/cli/conf.d/20-swoole.ini \
+       php8.3-memcached php8.3-pcov php8.3-imagick php8.3-xdebug php8.3-swoole \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
The new version is released, which reverts back to Swore 5.4.1:

Running `apt list php8.3-swoole` gives

php8.3-swoole/focal 6.0.0+really+5.1.4-1+ubuntu20.04.1+deb.sury.org+1 amd64

See also:
- https://github.com/oerdnj/deb.sury.org/issues/2205
- https://github.com/swoole/swoole-src/releases/tag/v5.1.4