### PR TITLE
[1.x] Ensure swoole's short functions are disabled

### DIFF
--- a/runtimes/8.0/php.ini
+++ b/runtimes/8.0/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname=off

--- a/runtimes/8.1/php.ini
+++ b/runtimes/8.1/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname=off

--- a/runtimes/8.2/php.ini
+++ b/runtimes/8.2/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname=off

--- a/runtimes/8.3/php.ini
+++ b/runtimes/8.3/php.ini
@@ -3,3 +3,4 @@ post_max_size = 100M
 upload_max_filesize = 100M
 variables_order = EGPCS
 pcov.directory = .
+swoole.use_shortname=off


### PR DESCRIPTION
This PR ensures that Swoole's short alias functions are disabled to allow Laravel's `defer` function to be used in Sail applications.

This is potentially breaking change for those who have not published the sail config to their own application and are using any swoole aliases.