### PR TITLE
Use /data path for minio

### DIFF
--- a/stubs/minio.stub
+++ b/stubs/minio.stub
@@ -7,10 +7,10 @@ minio:
         MINIO_ROOT_USER: 'sail'
         MINIO_ROOT_PASSWORD: 'password'
     volumes:
-        - 'sail-minio:/data/minio'
+        - 'sail-minio:/data'
     networks:
         - sail
-    command: minio server /data/minio --console-address ":8900"
+    command: minio server /data --console-address ":8900"
     healthcheck:
         test: ["CMD", "mc", "ready", "local"]
         retries: 3


### PR DESCRIPTION
Please see <https://hub.docker.com/r/minio/minio>.

If you use `/data/minio`, it may create two volumes (see https://github.com/minio/minio/issues/20534#issuecomment-2399415267).
