### PR TITLE
Run composer install in dev container

### DIFF
--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -19,6 +19,7 @@
 		}
 	},
 	"remoteUser": "sail",
+	"initializeCommand": "docker run --rm -u \"$(id -u):$(id -g)\" -v \"$(pwd):/var/www/html\" -w /var/www/html laravelsail/php83-composer:latest composer install --ignore-platform-reqs",
 	"postCreateCommand": "chown -R 1000:1000 /var/www/html 2>/dev/null || true"
 	// "forwardPorts": [],
 	// "runServices": [],


### PR DESCRIPTION
Today, starting a dev container using `curl -s "https://laravel.build/example-app?with=mysql,redis&devcontainer" | bash` (or any version with a dev container I assume), it works great. However, if I push that repo to GitHub and clone it back down, the dev container will not start.

That happens because the docker-compose.yml refers to ./vendor, which of course doesn't exist (yet).

I have done some testing on my end, and running this command before creating the dev container ensures that `./vendor/laravel/sail/runtimes/8.3(/Dockerfile)` exists before trying to create the container.

The command is from https://laravel.com/docs/11.x/sail#installing-composer-dependencies-for-existing-projects

For this to work, you would need to add the following to the .env file:
```env
WWWGROUP=1000
WWWUSER=1000
```

This PR, or something like it, aims to make it easier for new developers to get started with the Laravel dev container.

Note: I am completely new to Laravel and somewhat new to Docker. If this is not the fix here, please let me know. 
