### PR TITLE
Update typesense.stub to correct version tag

### DIFF
--- a/stubs/typesense.stub
+++ b/stubs/typesense.stub
@@ -1,5 +1,5 @@
 typesense:
-    image: 'typesense/typesense:0.27.1'
+    image: 'typesense/typesense:27.1'
     ports:
         - '${FORWARD_TYPESENSE_PORT:-8108}:8108'
     environment:


### PR DESCRIPTION
The publisher has switched from the prefixed 0.* tag style to 27.1 as of 27.*