### PR TITLE
fix: Use xdg-open if open does not exist

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -561,6 +561,15 @@ elif [ "$1" == "share" ]; then
 elif [ "$1" == "open" ]; then
     shift 1
 
+    if command -v open &>/dev/null; then
+        OPEN="open"
+    elif command -v xdg-open &>/dev/null; then
+        OPEN="xdg-open"
+    else
+        echo "Neither open nor xdg-open is available. Exiting."
+        exit 1
+    fi
+
     if [ "$EXEC" == "yes" ]; then
 
         if [[ -n "$APP_PORT" && "$APP_PORT" != "80" ]]; then
@@ -569,7 +578,7 @@ elif [ "$1" == "open" ]; then
             FULL_URL="$APP_URL"
         fi
 
-        open "$FULL_URL"
+        $OPEN "$FULL_URL"
 
         exit
     else


### PR DESCRIPTION
Solves #743 

Open is a macos tool.

On linux systems, xdg-open is commonly used instead. Tested this locally and works like a charm.
