### PR TITLE
Add "xdebug.start_with_request=yes" ini override

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -62,6 +62,7 @@ RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.0/cli/conf.d/99-sail.ini
+RUN echo "xdebug.start_with_request=yes" >> /etc/php/8.0/cli/conf.d/99-xdebug.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -61,6 +61,7 @@ RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.1/cli/conf.d/99-sail.ini
+RUN echo "xdebug.start_with_request=yes" >> /etc/php/8.1/cli/conf.d/99-xdebug.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -62,6 +62,7 @@ RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.2/cli/conf.d/99-sail.ini
+RUN echo "xdebug.start_with_request=yes" >> /etc/php/8.2/cli/conf.d/99-xdebug.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -63,6 +63,7 @@ RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.3/cli/conf.d/99-sail.ini
+RUN echo "xdebug.start_with_request=yes" >> /etc/php/8.3/cli/conf.d/99-xdebug.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -64,6 +64,7 @@ RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY php.ini /etc/php/8.4/cli/conf.d/99-sail.ini
+RUN echo "xdebug.start_with_request=yes" >> /etc/php/8.4/cli/conf.d/99-xdebug.ini
 RUN chmod +x /usr/local/bin/start-container
 
 EXPOSE 80/tcp


### PR DESCRIPTION
… to enable enable "trigger-less" step debugging in IDE's.

The benefit of this is that developers do NOT need to add anything extra to the query params (e.g. `?XDEBUG_TRIGGER=foo`) or POST body or COOKIES, to activate step debugging. As long as the debugger is listening and a breakpoint is hit, execution will be paused.

---

Here is a sample VS Code debug configuration (auto-generated, except for the `pathMappings`):
```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Listen for Xdebug",
            "type": "php",
            "request": "launch",
            "pathMappings": {
                "/var/www/html": "${workspaceFolder}"
            },
            "port": 9003
        }
    ]
}
```

---

And here is a screenshot of what it looks like:
<img width="1728" alt="Screenshot 2024-11-09 at 10 20 32 PM" src="https://github.com/user-attachments/assets/308a3049-66e3-467c-9080-e814ec8047fe">


<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
