### PR TITLE
[Feat] SSH Server opt-in

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -12,6 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -59,6 +60,15 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssh-server \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /var/run/sshd
+RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -13,7 +13,6 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -13,6 +13,7 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
+ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -66,8 +67,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd
-RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -9,7 +9,7 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
-if [ ! -z "$SSH_PASSWORD"]; then
+if [ ! -z "$SSH_PASSWORD" ]; then
     echo "sail:$SSH_PASSWORD" | chpasswd
 fi
 

--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$SSH_PASSWORD"]; then
+    echo "sail:$SSH_PASSWORD" | chpasswd
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:ssh]
+command=%(ENV_SUPERVISOR_SSH_COMMAND)s
+user=root
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -13,7 +13,6 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -66,7 +65,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -13,6 +13,7 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
+ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -65,8 +66,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd
-RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -12,6 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -58,6 +59,15 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssh-server \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /var/run/sshd
+RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -9,7 +9,7 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
-if [ ! -z "$SSH_PASSWORD"]; then
+if [ ! -z "$SSH_PASSWORD" ]; then
     echo "sail:$SSH_PASSWORD" | chpasswd
 fi
 

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$SSH_PASSWORD"]; then
+    echo "sail:$SSH_PASSWORD" | chpasswd
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:ssh]
+command=%(ENV_SUPERVISOR_SSH_COMMAND)s
+user=root
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -13,7 +13,6 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -67,7 +66,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -13,6 +13,7 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
+ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -66,8 +67,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd
-RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -12,6 +12,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -59,6 +60,15 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssh-server \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /var/run/sshd
+RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.2/start-container
+++ b/runtimes/8.2/start-container
@@ -9,7 +9,7 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
-if [ ! -z "$SSH_PASSWORD"]; then
+if [ ! -z "$SSH_PASSWORD" ]; then
     echo "sail:$SSH_PASSWORD" | chpasswd
 fi
 

--- a/runtimes/8.2/start-container
+++ b/runtimes/8.2/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$SSH_PASSWORD"]; then
+    echo "sail:$SSH_PASSWORD" | chpasswd
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:ssh]
+command=%(ENV_SUPERVISOR_SSH_COMMAND)s
+user=root
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -13,6 +13,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -60,6 +61,15 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssh-server \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /var/run/sshd
+RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -14,6 +14,7 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
+ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -67,8 +68,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd
-RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -14,7 +14,6 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -68,7 +67,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.3/start-container
+++ b/runtimes/8.3/start-container
@@ -9,7 +9,7 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
-if [ ! -z "$SSH_PASSWORD"]; then
+if [ ! -z "$SSH_PASSWORD" ]; then
     echo "sail:$SSH_PASSWORD" | chpasswd
 fi
 

--- a/runtimes/8.3/start-container
+++ b/runtimes/8.3/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$SSH_PASSWORD"]; then
+    echo "sail:$SSH_PASSWORD" | chpasswd
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:ssh]
+command=%(ENV_SUPERVISOR_SSH_COMMAND)s
+user=root
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -14,7 +14,7 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-
+ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -69,8 +69,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd
-RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -13,6 +13,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
+
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -61,6 +63,15 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.4
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y openssh-server \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN mkdir /var/run/sshd
+RUN useradd -m -s /bin/bash sail && echo "sail:sail" | chpasswd && usermod -aG sudo sail
+RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -14,7 +14,6 @@ ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
 ENV SUPERVISOR_SSH_COMMAND="/usr/sbin/sshd -D"
-ENV SSH_PASSWORD="sail"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -69,7 +68,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN mkdir /var/run/sshd && RUN echo "sail:${SSH_PASSWORD}" | chpasswd && usermod -aG sudo sail
+RUN mkdir /var/run/sshd
 RUN sed -i 's/#PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config
 
 COPY start-container /usr/local/bin/start-container

--- a/runtimes/8.4/start-container
+++ b/runtimes/8.4/start-container
@@ -9,7 +9,7 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
-if [ ! -z "$SSH_PASSWORD"]; then
+if [ ! -z "$SSH_PASSWORD" ]; then
     echo "sail:$SSH_PASSWORD" | chpasswd
 fi
 

--- a/runtimes/8.4/start-container
+++ b/runtimes/8.4/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$SSH_PASSWORD"]; then
+    echo "sail:$SSH_PASSWORD" | chpasswd
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.4/supervisord.conf
+++ b/runtimes/8.4/supervisord.conf
@@ -12,3 +12,12 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:ssh]
+command=%(ENV_SUPERVISOR_SSH_COMMAND)s
+user=root
+environment=LARAVEL_SAIL="1"
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -10,6 +10,7 @@ services:
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         ports:
+            # - '${SSH_PORT:-2222}:22'
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -14,7 +14,7 @@ services:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
-            # SSH_PASSWORD: 'sail'
+            # SSH_PASSWORD:
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -14,6 +14,7 @@ services:
             - '${APP_PORT:-80}:80'
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
+            # SSH_PASSWORD: 'sail'
             WWWUSER: '${WWWUSER}'
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'


### PR DESCRIPTION
This PR adds an SSH Server to the DevContainer (opt-in), with the purpose of letting the developer connect remotely on situations where he doesn't have a mature DevContainer provisioner or just needs a remote connection from _elsewhere_.

The developer only needs to uncomment the port and set a password.

```yaml
services:
    laravel.test:
        ports:
            # - '${SSH_PORT:-2222}:22'
        environment:
            # SSH_PASSWORD: 
```

> [!NOTE]
>
> If the password is empty, the user won't be able to log in.

This is done installing OpenSSH, and starting an SSH Server along PHP through Supervisor.

The DevContainer provisioner has no obligation to serve an SSH Server via network. For example, DevPod uses stdio, while others may use file sockets or expose the Docker Machine to the network (overkill for a single proyect), hence why this patch. 