### PR TITLE
Add `sail run` command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -112,6 +112,7 @@ function display_help {
     echo
     echo "${YELLOW}Binaries:${NC}"
     echo "  ${GREEN}sail bin ...${NC}   Run Composer binary scripts from the vendor/bin directory"
+    echo "  ${GREEN}sail run ...${NC}   Run any command within the application container"
     echo
     echo "${YELLOW}Customization:${NC}"
     echo "  ${GREEN}sail artisan sail:publish${NC}   Publish the Sail configuration files"
@@ -229,6 +230,20 @@ elif [ "$1" == "bin" ]; then
         ARGS+=(exec -u sail)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=("$APP_SERVICE" ./vendor/bin/"$CMD")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy commands on the application container...
+elif [ "$1" == "run" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        CMD=$1
+        shift 1
+        ARGS+=(exec -u sail)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "$CMD")
     else
         sail_is_not_running
     fi

--- a/bin/sail
+++ b/bin/sail
@@ -112,7 +112,7 @@ function display_help {
     echo
     echo "${YELLOW}Binaries:${NC}"
     echo "  ${GREEN}sail bin ...${NC}   Run Composer binary scripts from the vendor/bin directory"
-    echo "  ${GREEN}sail run ...${NC}   Run any command within the application container"
+    echo "  ${GREEN}sail run ...${NC}   Run a command within the application container"
     echo
     echo "${YELLOW}Customization:${NC}"
     echo "  ${GREEN}sail artisan sail:publish${NC}   Publish the Sail configuration files"


### PR DESCRIPTION
This PR adds the `sail run` command which allows us to run commands directly in the container.

I often create bash scripts in my projects in order to run a series of artisan command (or any command for that matter). In order to run these commands we currently have to do the following:

Open bash in the container:
```
$ sail bash
```

Then within the container:
```
$ ./some/path/to/a/command
```

With the `sail run` command we could just call it at once:
```
$ sail run some/path/to/a/command
```

PS: I considered expanding the `sail bin` command at first, but figured it would be safer to just add a new command instead. Please let me know if anyone feels different about this!