### PR TITLE
[1.x] Add suggestion to configure Sail shell alias in display_help for easier command usage

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -24,6 +24,8 @@ if test -t 1; then
         BOLD="$(tput bold)"
         YELLOW="$(tput setaf 3)"
         GREEN="$(tput setaf 2)"
+        MAGENTA="$(tput setaf 5)"
+        CYAN="$(tput setaf 6)"
         NC="$(tput sgr0)"
     fi
 fi
@@ -37,6 +39,18 @@ function display_help {
     echo
     echo "Unknown commands are passed to the docker-compose binary."
     echo
+    if ! grep -q "alias sail=" ~/.bashrc ~/.zshrc 2>/dev/null; then
+        echo "${YELLOW}Configuring A Shell Alias:${NC}"
+        echo "However, instead of repeatedly typing ./bin/sail to execute Sail commands,"
+        echo "you may wish to configure a shell alias that allows you to execute Sail's commands more easily:"
+        echo
+        echo "${BOLD}${MAGENTA}alias ${YELLOW}sail${MAGENTA}=${CYAN}'bash \$([ -f sail ] && echo sail || echo bin/sail)'${NC}"
+        echo
+        echo "To make sure this is always available,"
+        echo "you may add this to your shell configuration file in your home directory,"
+        echo "such as ${YELLOW}${BOLD}~/.zshrc${NC} or ${YELLOW}${BOLD}~/.bashrc${NC}, and then restart your shell."
+        echo
+    fi
     echo "${YELLOW}docker-compose Commands:${NC}"
     echo "  ${GREEN}sail up${NC}        Start the application"
     echo "  ${GREEN}sail up -d${NC}     Start the application in the background"


### PR DESCRIPTION
### Summary:
This PR adds a suggestion to the `display_help` function in Sail, encouraging users to configure a shell alias for easier execution of Sail commands. If the alias is not already configured in the `.bashrc` or `.zshrc` files, the script will provide instructions on how to set it up.

### Benefits to End Users:
- **Ease of Use**: This change simplifies the process of running Sail commands by allowing users to use a shorter and easier-to-remember alias (`sail`) instead of typing `./bin/sail` every time.
- **Improved UX**: By proactively suggesting the alias setup, it improves the overall user experience for those new to Sail or those who may not be aware of this configuration option.

### Why It Doesn't Break Any Existing Features:
- This change only adds a suggestion and does not alter any existing Sail functionality.
- The alias check and suggestion are non-intrusive and only displayed when the alias is not configured.
- The functionality of the `sail` command remains unchanged.

### How It Makes Building Web Applications Easier:
- By setting up the alias, developers save time and reduce potential errors caused by typing long commands.
- This small but impactful improvement streamlines the workflow, particularly for those working with Laravel Sail in a local development environment.

### How to Test:
1. Ensure that the `sail` alias is not present in your `.bashrc` or `.zshrc` file.
2. Run the `display_help` command.
3. If the alias is not found, you should see a message suggesting how to configure the alias.
4. Add the alias to your shell configuration file as instructed and confirm that it works.
