### PR TITLE
Fix `DB_DATABASE` replacement in `phpunit.xml`

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -226,7 +226,14 @@ trait InteractsWithDockerComposeServices
         $phpunit = file_get_contents($path);
 
         $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
-        $phpunit = str_replace('<!-- <env name="DB_DATABASE" value=":memory:"/> -->', '<env name="DB_DATABASE" value="testing"/>', $phpunit);
+        $phpunit = str_replace(
+            [
+                '<!-- <env name="DB_DATABASE" value=":memory:"/> -->',
+                '<env name="DB_DATABASE" value=":memory:"/>',
+            ],
+            '<env name="DB_DATABASE" value="testing"/>',
+            $phpunit
+        );
 
         file_put_contents($this->laravel->basePath('phpunit.xml'), $phpunit);
     }


### PR DESCRIPTION
Since this [commit](https://github.com/laravel/laravel/commit/7a7015534e6cdde94a8d9e224b98a20735b11491) in the skeleton, the Sail installation doesn't work correctly for updating the `DB_DATABASE` value in `phpunit.xml` on new Laravel applications.

This PR updates the search pattern to match both commented and uncommented lines, ensuring compatibility with projects created both before and after this update.
