### PR TITLE
Add the hostname for RabbitMQ

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -24,9 +24,9 @@ trait InteractsWithDockerComposeServices
         'typesense',
         'minio',
         'mailpit',
+        'rabbitmq',
         'selenium',
         'soketi',
-        'rabbitmq',
     ];
 
     /**

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -26,6 +26,7 @@ trait InteractsWithDockerComposeServices
         'mailpit',
         'selenium',
         'soketi',
+        'rabbitmq',
     ];
 
     /**
@@ -203,6 +204,10 @@ trait InteractsWithDockerComposeServices
             $environment = preg_replace("/^MAIL_MAILER=(.*)/m", "MAIL_MAILER=smtp", $environment);
             $environment = preg_replace("/^MAIL_HOST=(.*)/m", "MAIL_HOST=mailpit", $environment);
             $environment = preg_replace("/^MAIL_PORT=(.*)/m", "MAIL_PORT=1025", $environment);
+        }
+
+        if (in_array('rabbitmq', $services)) {
+            $environment = str_replace('RABBITMQ_HOST=127.0.0.1', 'RABBITMQ_HOST=rabbitmq', $environment);
         }
 
         file_put_contents($this->laravel->basePath('.env'), $environment);

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -10,7 +10,7 @@ rabbitmq:
         RABBITMQ_VHOST: '${RABBITMQ_VHOST}'
         RABBITMQ_QUEUE: '${RABBITMQ_QUEUE}'
     volumes:
-        - 'sail-rabbitmq:/rabbitmq_data'
+        - 'sail-rabbitmq:/var/lib/rabbitmq'
     networks:
         - sail
     healthcheck:

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -1,5 +1,6 @@
 rabbitmq:
     image: 'rabbitmq:4-management'
+    hostname: 'rabbitmq'
     ports:
         - '${FORWARD_RABBITMQ_PORT:-5672}:5672'
         - '${FORWARD_RABBITMQ_DASHBOARD_PORT:-15672}:15672'

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -1,5 +1,5 @@
 rabbitmq:
-    image: 'rabbitmq:4'
+    image: 'rabbitmq:4-management'
     ports:
         - '${FORWARD_RABBITMQ_PORT:-5672}:5672'
         - '${FORWARD_RABBITMQ_DASHBOARD_PORT:-15672}:15672'

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -10,7 +10,7 @@ rabbitmq:
         RABBITMQ_VHOST: '${RABBITMQ_VHOST}'
         RABBITMQ_QUEUE: '${RABBITMQ_QUEUE}'
     volumes:
-        - 'sail-rabbitmq:/var/lib/rabbitmq'
+        - 'sail-rabbitmq:/rabbitmq_data'
     networks:
         - sail
     healthcheck:

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -1,0 +1,19 @@
+rabbitmq:
+    image: 'rabbitmq:4'
+    ports:
+        - '${FORWARD_RABBITMQ_PORT:-5672}:5672'
+        - '${FORWARD_RABBITMQ_DASHBOARD_PORT:-15672}:15672'
+    environment:
+        RABBITMQ_HOST: "%"
+        RABBITMQ_USER: '${RABBITMQ_USER}'
+        RABBITMQ_PASSWORD: '${RABBITMQ_PASSWORD}'
+        RABBITMQ_VHOST: '${RABBITMQ_VHOST}'
+        RABBITMQ_QUEUE: '${RABBITMQ_QUEUE}'
+    volumes:
+        - 'sail-rabbitmq:/rabbitmq_data'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+        retries: 3
+        timeout: 5s


### PR DESCRIPTION
If the hostname is not provided, a random hostname is created each time the service is restarted, and the rabbitmq service cannot access its stored data. :male_detective: 
