### PR TITLE
Rename service name laravel.test to laravel-test to fix bake issues

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -140,7 +140,7 @@ fi
 
 # Define environment variables...
 export APP_PORT=${APP_PORT:-80}
-export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
+export APP_SERVICE=${APP_SERVICE:-"laravel-test"}
 export APP_USER=${APP_USER:-"sail"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -70,14 +70,14 @@ trait InteractsWithDockerComposeServices
 
         // Prepare the installation of the "mariadb-client" package if the MariaDB service is used...
         if (in_array('mariadb', $services)) {
-            $compose['services']['laravel.test']['build']['args']['MYSQL_CLIENT'] = 'mariadb-client';
+            $compose['services']['laravel-test']['build']['args']['MYSQL_CLIENT'] = 'mariadb-client';
         }
 
-        // Adds the new services as dependencies of the laravel.test service...
-        if (! array_key_exists('laravel.test', $compose['services'])) {
-            $this->warn('Couldn\'t find the laravel.test service. Make sure you add ['.implode(',', $services).'] to the depends_on config.');
+        // Adds the new services as dependencies of the laravel-test service...
+        if (! array_key_exists('laravel-test', $compose['services'])) {
+            $this->warn('Couldn\'t find the laravel-test service. Make sure you add ['.implode(',', $services).'] to the depends_on config.');
         } else {
-            $compose['services']['laravel.test']['depends_on'] = collect($compose['services']['laravel.test']['depends_on'] ?? [])
+            $compose['services']['laravel-test']['depends_on'] = collect($compose['services']['laravel-test']['depends_on'] ?? [])
                 ->merge($services)
                 ->unique()
                 ->values()

--- a/stubs/devcontainer.stub
+++ b/stubs/devcontainer.stub
@@ -4,7 +4,7 @@
 	"dockerComposeFile": [
 		"../docker-compose.yml"
 	],
-	"service": "laravel.test",
+	"service": "laravel-test",
 	"workspaceFolder": "/var/www/html",
 	"customizations": {
 		"vscode": {

--- a/stubs/docker-compose.stub
+++ b/stubs/docker-compose.stub
@@ -1,6 +1,6 @@
 # For more information: https://laravel.com/docs/sail
 services:
-    laravel.test:
+    laravel-test:
         build:
             context: ./vendor/laravel/sail/runtimes/{{PHP_VERSION}}
             dockerfile: Dockerfile


### PR DESCRIPTION
This fixes issues with docker compose and bake.  Closes #786.

Docker changed the default way of building images. By default they're going to use now docker buildx bake to do so. 

Apparently this causes issues when service name contains `.` character in it. I'm going to draft this PR as I'm not convinced this change is actually necessary and it might be just a bug in docker compose + bake integration. I'll open issue with them. 

I did a lot of digging around the docker code and it seems that bake really shouldn't be returning `-.json:10,5-19: Invalid name; only "[a-zA-Z0-9_-]+" are allowed`.

