### PR TITLE
Add tests for laravel 12 and supported vers of php

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,12 @@ jobs:
             laravel: 11
           - php: '8.4'
             laravel: 11
+          - php: '8.2'
+            laravel: 12
+          - php: '8.3'
+            laravel: 12
+          - php: '8.4'
+            laravel: 12
 
     name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,16 +18,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - php: '8.0'
-            laravel: 9
-          - php: '8.1'
-            laravel: 10
-          - php: '8.2'
-            laravel: 11
-          - php: '8.3'
-            laravel: 11
-          - php: '8.4'
-            laravel: 11
           - php: '8.2'
             laravel: 12
           - php: '8.3'


### PR DESCRIPTION
This adds missing tests for laravel 12 and all supported by it versions of PHP.
