### PR TITLE
Feature: Allow passing in extra options to MYSQL executable

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -489,7 +489,7 @@ elif [ "$1" == "mysql" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(mysql bash -c)
-        ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE}")
+        ARGS+=("MYSQL_PWD=\${MYSQL_PASSWORD} mysql -u \${MYSQL_USER} \${MYSQL_DATABASE} \${MYSQL_EXTRA_OPTIONS}")
     else
         sail_is_not_running
     fi

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -9,7 +9,7 @@ mysql:
         MYSQL_USER: '${DB_USERNAME}'
         MYSQL_PASSWORD: '${DB_PASSWORD}'
         MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS:-""}
+        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS}
     volumes:
         - 'sail-mysql:/var/lib/mysql'
         - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -9,6 +9,7 @@ mysql:
         MYSQL_USER: '${DB_USERNAME}'
         MYSQL_PASSWORD: '${DB_PASSWORD}'
         MYSQL_ALLOW_EMPTY_PASSWORD: 1
+        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS:-""}
     volumes:
         - 'sail-mysql:/var/lib/mysql'
         - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'

--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -9,7 +9,7 @@ mysql:
         MYSQL_USER: '${DB_USERNAME}'
         MYSQL_PASSWORD: '${DB_PASSWORD}'
         MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS}
+        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS}'
     volumes:
         - 'sail-mysql:/var/lib/mysql'
         - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This PR adds an extra environment variable to the docker-compose `mysql.stub` file: `MYSQL_EXTRA_OPTIONS` (empty string by default).
This option is then read by the sail shell script and appended to the mysql command.

So if you have something like this in your laravel's `.env` project

```dotenv
# .env
MYSQL_EXTRA_OPTIONS="--default-character-set=utf8mb4 --more --options --here"
```
`sail mysql` will now load those options as well.

Before, the alternative was using the full `docker exec` command.

```
docker exec -it laravel-project-mysql-1 mysql -usail -ppassword database --default-character-set=utf8mb4
```
