### PR TITLE
Feature/scheduler sail

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
 
 RUN apt-get update && apt-get upgrade -y \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano cron \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
@@ -59,6 +59,10 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+COPY scheduler /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.0/scheduler
+++ b/runtimes/8.0/scheduler
@@ -1,0 +1,1 @@
+* * * * * root cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -12,3 +12,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log

--- a/runtimes/8.0/supervisord.conf
+++ b/runtimes/8.0/supervisord.conf
@@ -17,4 +17,6 @@ stderr_logfile_maxbytes=0
 command=/usr/sbin/cron -f -l 8
 autostart=true
 stdout_logfile=/var/log/cron.out.log
+stdout_logfile_maxbytes=0
 stderr_logfile=/var/log/cron.err.log
+stderr_logfile_maxbytes=0

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
 
 RUN apt-get update && apt-get upgrade -y \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano cron \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
@@ -58,6 +58,10 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+COPY scheduler /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.1/scheduler
+++ b/runtimes/8.1/scheduler
@@ -1,0 +1,1 @@
+* * * * * root cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -12,3 +12,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log

--- a/runtimes/8.1/supervisord.conf
+++ b/runtimes/8.1/supervisord.conf
@@ -17,4 +17,6 @@ stderr_logfile_maxbytes=0
 command=/usr/sbin/cron -f -l 8
 autostart=true
 stdout_logfile=/var/log/cron.out.log
+stdout_logfile_maxbytes=0
 stderr_logfile=/var/log/cron.err.log
+stderr_logfile_maxbytes=0

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -21,7 +21,7 @@ RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
 
 RUN apt-get update && apt-get upgrade -y \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano  \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano cron \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
@@ -59,6 +59,10 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+COPY scheduler /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.2/scheduler
+++ b/runtimes/8.2/scheduler
@@ -1,0 +1,1 @@
+* * * * * root cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -12,3 +12,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log

--- a/runtimes/8.2/supervisord.conf
+++ b/runtimes/8.2/supervisord.conf
@@ -17,4 +17,6 @@ stderr_logfile_maxbytes=0
 command=/usr/sbin/cron -f -l 8
 autostart=true
 stdout_logfile=/var/log/cron.out.log
+stdout_logfile_maxbytes=0
 stderr_logfile=/var/log/cron.err.log
+stderr_logfile_maxbytes=0

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
 
 RUN apt-get update && apt-get upgrade -y \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano  \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano cron \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
@@ -60,6 +60,10 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+COPY scheduler /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.3/scheduler
+++ b/runtimes/8.3/scheduler
@@ -1,0 +1,1 @@
+* * * * * root cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -12,3 +12,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log

--- a/runtimes/8.3/supervisord.conf
+++ b/runtimes/8.3/supervisord.conf
@@ -17,4 +17,6 @@ stderr_logfile_maxbytes=0
 command=/usr/sbin/cron -f -l 8
 autostart=true
 stdout_logfile=/var/log/cron.out.log
+stdout_logfile_maxbytes=0
 stderr_logfile=/var/log/cron.err.log
+stderr_logfile_maxbytes=0

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -22,7 +22,7 @@ RUN echo "Acquire::http::Pipeline-Depth 0;" > /etc/apt/apt.conf.d/99custom && \
 
 RUN apt-get update && apt-get upgrade -y \
     && mkdir -p /etc/apt/keyrings \
-    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano  \
+    && apt-get install -y gnupg gosu curl ca-certificates zip unzip git supervisor sqlite3 libcap2-bin libpng-dev python3 dnsutils librsvg2-bin fswatch ffmpeg nano cron  \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
@@ -60,6 +60,10 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.4
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+
+COPY scheduler /etc/cron.d/scheduler
+RUN chmod 0644 /etc/cron.d/scheduler \
+    && crontab /etc/cron.d/scheduler
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.4/scheduler
+++ b/runtimes/8.4/scheduler
@@ -1,0 +1,1 @@
+* * * * * root cd /var/www/html && php artisan schedule:run >> /dev/null 2>&1

--- a/runtimes/8.4/supervisord.conf
+++ b/runtimes/8.4/supervisord.conf
@@ -12,3 +12,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:cron]
+command=/usr/sbin/cron -f -l 8
+autostart=true
+stdout_logfile=/var/log/cron.out.log
+stderr_logfile=/var/log/cron.err.log

--- a/runtimes/8.4/supervisord.conf
+++ b/runtimes/8.4/supervisord.conf
@@ -17,4 +17,6 @@ stderr_logfile_maxbytes=0
 command=/usr/sbin/cron -f -l 8
 autostart=true
 stdout_logfile=/var/log/cron.out.log
+stdout_logfile_maxbytes=0
 stderr_logfile=/var/log/cron.err.log
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
This pull request introduces cron job support across multiple PHP runtime Dockerfiles (8.0 through 8.4) to enable scheduled task execution. It includes updates to install and configure the `cron` service, add a scheduler configuration, and ensure proper logging for cron jobs.

### Cron job support across PHP runtimes:

* Added `cron` to the list of installed packages in `Dockerfile` for PHP runtimes 8.0, 8.1, 8.2, 8.3, and 8.4. (`runtimes/8.0/Dockerfile` [[1]](diffhunk://#diff-e9023f2c440627008776bae3dca38d860595d34e01bace4929cf39cadf2060c8L24-R24) `runtimes/8.1/Dockerfile` [[2]](diffhunk://#diff-ba177ef3ded1559aa470199ddd0d9596edb6f6e1802ed49e000c0b5bddba039aL24-R24) `runtimes/8.2/Dockerfile` [[3]](diffhunk://#diff-bf62478de54abea2e3fee9d119dc62e8bb2456d325ad11182fa6a5479c4f6dbbL24-R24) `runtimes/8.3/Dockerfile` [[4]](diffhunk://#diff-a08dd7954d77702c830274a4b8ef6c507e70cb20c81a03a22859ae7ed524b777L25-R25) `runtimes/8.4/Dockerfile` [[5]](diffhunk://#diff-7b2daecfb7a553ffec00fe851030d227a2fc437c6481884185c5c83ae06c8007L25-R25)
* Added a cron scheduler file (`scheduler`) to execute Laravel's `schedule:run` command every minute. This file is copied to `/etc/cron.d/` and registered with `crontab` in the respective `Dockerfile`. (`runtimes/8.0/Dockerfile` [[1]](diffhunk://#diff-e9023f2c440627008776bae3dca38d860595d34e01bace4929cf39cadf2060c8R63-R66) `runtimes/8.1/Dockerfile` [[2]](diffhunk://#diff-ba177ef3ded1559aa470199ddd0d9596edb6f6e1802ed49e000c0b5bddba039aR62-R65) `runtimes/8.2/Dockerfile` [[3]](diffhunk://#diff-bf62478de54abea2e3fee9d119dc62e8bb2456d325ad11182fa6a5479c4f6dbbR63-R66) `runtimes/8.3/Dockerfile` [[4]](diffhunk://#diff-a08dd7954d77702c830274a4b8ef6c507e70cb20c81a03a22859ae7ed524b777R64-R67) `runtimes/8.4/Dockerfile` [[5]](diffhunk://#diff-7b2daecfb7a553ffec00fe851030d227a2fc437c6481884185c5c83ae06c8007R64-R67); `runtimes/8.0/scheduler`, `runtimes/8.1/scheduler`, `runtimes/8.2/scheduler`, `runtimes/8.3/scheduler`, `runtimes/8.4/scheduler` [[6]](diffhunk://#diff-00d1a50ab524acdcc8a470b95196e2f1b4d0dad9a77567bc62394a58251e4da8R1)
* Updated `supervisord.conf` for all runtimes to include a new program configuration for `cron`, ensuring it runs in the foreground and logs output to dedicated files. (`runtimes/8.0/supervisord.conf`, `runtimes/8.1/supervisord.conf`, `runtimes/8.2/supervisord.conf`, `runtimes/8.3/supervisord.conf`, `runtimes/8.4/supervisord.conf` [runtimes/8.0/supervisord.confR15-R22](diffhunk://#diff-eedea53790dd3beba21897015dfb46768577526ca9fc99c86d0c60fc5101bca2R15-R22))
