### PR TITLE
Update PostgreSQL and RabbitMQ stubs to use Alpine variants

### DIFF
--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -1,5 +1,5 @@
 pgsql:
-    image: 'postgres:17'
+    image: 'postgres:17-alpine'
     ports:
         - '${FORWARD_DB_PORT:-5432}:5432'
     environment:

--- a/stubs/rabbitmq.stub
+++ b/stubs/rabbitmq.stub
@@ -1,5 +1,5 @@
 rabbitmq:
-    image: 'rabbitmq:4-management'
+    image: 'rabbitmq:4-management-alpine'
     hostname: 'rabbitmq'
     ports:
         - '${FORWARD_RABBITMQ_PORT:-5672}:5672'


### PR DESCRIPTION
This PR updates Postgres and RabbitMQ stubs to use the Alpine variants to make use of the lighter images.

- Postgres: `620.72 MB` -> `398.33 MB`
- RabbitMQ: `425.63 MB` -> `313.23 MB`