### PR TITLE
feat: Allow Laravel Sail to run Pest 4 Browser tests

### DIFF
--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -13,6 +13,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+# Install Pest 4 browsers on node_modules
+ENV PLAYWRIGHT_BROWSERS_PATH=0 
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -43,6 +45,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npx playwright install-deps \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -13,7 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
-# Install Pest 4 browsers on node_modules
 ENV PLAYWRIGHT_BROWSERS_PATH=0 
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -13,6 +13,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
+# Install Pest 4 browsers on node_modules
+ENV PLAYWRIGHT_BROWSERS_PATH=0 
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
@@ -43,6 +45,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npx playwright install-deps \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -13,7 +13,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 ENV SUPERVISOR_PHP_COMMAND="/usr/bin/php -d variables_order=EGPCS /var/www/html/artisan serve --host=0.0.0.0 --port=80"
 ENV SUPERVISOR_PHP_USER="sail"
-# Install Pest 4 browsers on node_modules
 ENV PLAYWRIGHT_BROWSERS_PATH=0 
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
This Merge request prepare Laravel Sail image to run Pest 4 Browser tests.

I don't know how to write automated tests for docker images, but this is working on my projects

---
## Aditional info (not required)
Besides this i had to include on package.json (but this change is related to PEST 4 package, i'll open a PR related to it on Pest 4 repo)
```
    "scripts": {
        ...
        "postinstall": "npx playwright install"
    },
    "devDependencies": {
        ...
        "playwright": "^1.55.0",
    },
```

Also i'm able to run the browser tests on my Github CI workflow
```yaml
name: tests

on:
  workflow_run:
    workflows: ["linter"]
    types:
      - completed
    branches:
      - develop
      - main

jobs:
  ci:
    runs-on: ubuntu-latest
    if: ${{ github.event.workflow_run.conclusion == 'success' }}
    env: 
      PLAYWRIGHT_BROWSERS_PATH: 0   #Install playwright browsers on node_modules

    steps:
      - name: Checkout
        uses: actions/checkout@v4

      - name: Setup PHP
        uses: shivammathur/setup-php@v2
        with:
          php-version: 8.4
          tools: composer:v2
          coverage: xdebug

      - name: Setup Node
        uses: actions/setup-node@v4
        with:
          node-version: '22'
          cache: 'npm'
          cache-dependency-path: './project/package-lock.json'

      # Required for PEST 4 browser tests
      - name: Install Playwright dependencies
        run: npx playwright install-deps

      - name: Install Node Dependencies
        working-directory: ./project
        run: npm install

      - name: Install Dependencies
        working-directory: ./project
        run: composer install --no-interaction --prefer-dist --optimize-autoloader

      - name: Copy Environment File
        working-directory: ./project
        run: cp .env.example .env

      - name: Generate Application Key
        working-directory: ./project
        run: php artisan key:generate

      - name: Build Assets
        working-directory: ./project
        run: npm run build

      - name: Tests
        working-directory: ./project
        # run: php artisan test --type-coverage --mutate --parallel
        run: php artisan test --parallel
```