### PR TITLE
mark working directory as safe with git

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -59,6 +59,7 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN git config --global --add safe.directory /var/www/html
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -58,6 +58,7 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN git config --global --add safe.directory /var/www/html
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -59,6 +59,7 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN git config --global --add safe.directory /var/www/html
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -62,6 +62,7 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN git config --global --add safe.directory /var/www/html
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -62,6 +62,7 @@ RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.4
 RUN userdel -r ubuntu
 RUN groupadd --force -g $WWWGROUP sail
 RUN useradd -ms /bin/bash --no-user-group -g $WWWGROUP -u 1337 sail
+RUN git config --global --add safe.directory /var/www/html
 
 COPY start-container /usr/local/bin/start-container
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf


### PR DESCRIPTION
Add safe.directory for /var/www/html to silence Git’s “dubious ownership” warnings in Sail images

<img width="1030" height="220" alt="image" src="https://github.com/user-attachments/assets/12047626-43e1-40df-b58f-26a0ff5f3bd9" />

This PR adds one line to each Sail PHP Dockerfile (8.0–8.4):

```
RUN git config --global --add safe.directory /var/www/html
```

### Why this is needed

When working inside Sail containers, Git often prints the warning:

fatal: detected dubious ownership in repository at '/var/www/html'

This is noisy and distracting during normal local development (e.g., running Composer scripts or simple git status), because the container’s active user/UID may not match the on-disk ownership of /var/www/html. Marking the working directory as a safe Git directory removes the warning without changing how folks use Sail day-to-day. 

### What causes the “dubious ownership” warning

In April 2022, Git shipped a [security fix](https://github.blog/open-source/git/git-security-vulnerability-announced/) hardening for CVE-2022-24765. As part of that fix, Git refuses to operate in a repository if the current user differs from the repository owner, unless the path is explicitly trusted via the safe.directory setting. This protects users on multi-user systems from configs/hooks in repos they don’t own. 

The behavior is documented in Git’s manuals: by default, Git will not run in repos owned by someone else; you can opt-in specific paths with safe.directory.

In containerized dev environments this mismatch is common (different UIDs inside the container vs. the mounted volume), which is why Sail users see the warning frequently. 

### Why this is safe for Sail

Sail is explicitly a local development environment—not a production runtime—and is intended to help developers get a Laravel app running with Docker on their own machine. Marking /var/www/html (the working dir inside Sail) as “safe” only suppresses the ownership check for that one path inside the container. It does not weaken Git’s checks globally, nor does it add any new privileges; it simply acknowledges that this specific, local dev path is trusted.