### PR TITLE
[1.x] Uncomment CLI workers on install

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -210,6 +210,8 @@ trait InteractsWithDockerComposeServices
             $environment = str_replace('RABBITMQ_HOST=127.0.0.1', 'RABBITMQ_HOST=rabbitmq', $environment);
         }
 
+        $environment = str_replace('# PHP_CLI_SERVER_WORKERS=4', 'PHP_CLI_SERVER_WORKERS=4', $environment);
+
         file_put_contents($this->laravel->basePath('.env'), $environment);
     }
 


### PR DESCRIPTION
Continuing on with https://github.com/laravel/framework/pull/57482.

I wasn't 100% on the best experience behaviour here. This will uncomment out the env for the current machine, which seems to be the current way things are handled.

I can see a world where we put this in the docker-compose.yml so everyone who pulls the project has the value set.

Let me know if you think it should be handled in another way.