### PR TITLE
Add rustfs service to Docker Compose and update service list

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -35,6 +35,7 @@ trait InteractsWithDockerComposeServices
         'meilisearch',
         'typesense',
         'minio',
+        'rustfs',
         'mailpit',
         'rabbitmq',
         'selenium',
@@ -107,7 +108,7 @@ trait InteractsWithDockerComposeServices
         // Merge volumes...
         collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'mongodb', 'redis', 'valkey', 'meilisearch', 'typesense', 'minio', 'rabbitmq']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'mongodb', 'redis', 'valkey', 'meilisearch', 'typesense', 'minio', 'rustfs', 'rabbitmq']);
             })->filter(function ($service) use ($compose) {
                 return ! array_key_exists($service, $compose['volumes'] ?? []);
             })->each(function ($service) use (&$compose) {

--- a/stubs/rustfs.stub
+++ b/stubs/rustfs.stub
@@ -13,6 +13,7 @@ rustfs:
         RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS: '*'
         RUSTFS_ACCESS_KEY: 'sail'
         RUSTFS_SECRET_KEY: 'password'
+        RUSTFS_LOG_LEVEL: 'info',
     volumes:
         - 'sail-rustfs:/data'
     networks:

--- a/stubs/rustfs.stub
+++ b/stubs/rustfs.stub
@@ -1,0 +1,30 @@
+rustfs:
+    image: 'rustfs/rustfs:latest'
+    ports:
+        - '${FORWARD_RUSTFS_PORT:-9000}:9000'
+        - '${FORWARD_RUSTFS_CONSOLE_PORT:-9001}:9001'
+    environment:
+        RUSTFS_VOLUMES: '/data'
+        RUSTFS_ADDRESS: '0.0.0.0:9000'
+        RUSTFS_CONSOLE_ADDRESS: '0.0.0.0:9001'
+        RUSTFS_CONSOLE_ENABLE: 'true'
+        RUSTFS_EXTERNAL_ADDRESS: ':9000'
+        RUSTFS_CORS_ALLOWED_ORIGINS: '*'
+        RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS: '*'
+        RUSTFS_ACCESS_KEY: 'sail'
+        RUSTFS_SECRET_KEY: 'password'
+    volumes:
+        - 'sail-rustfs:/data'
+    networks:
+        - sail
+    healthcheck:
+        test:
+        [
+          "CMD",
+          "sh", "-c",
+          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/health"
+        ]
+        interval: 30s
+        timeout: 10s
+        retries: 3
+        start_period: 40s


### PR DESCRIPTION
This pull request adds support for the `rustfs`, solving https://github.com/laravel/sail/issues/820.

I tried a few other alternatives, like [Garage](https://garagehq.deuxfleurs.fr/) and [JuiceFS](https://juicefs.com/en/), although they may be more powerful, I didn't find a relatively simply drop-in replacement for MinIO for (local) development.

Could you please test this? I'm creating this as a draft, because I can test this only later on Monday, the syntax looks correctly.