### PR TITLE
Fix(sail): Correct YAML syntax in rustfs.stub healthcheck

### DIFF
--- a/stubs/rustfs.stub
+++ b/stubs/rustfs.stub
@@ -19,11 +19,7 @@ rustfs:
     networks:
         - sail
     healthcheck:
-        test:
-          - "CMD"
-          - "sh"
-          - "-c"
-          - "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/health"
+        test: ["CMD", "sh", "-c", "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/health"]
         interval: 30s
         timeout: 10s
         retries: 3

--- a/stubs/rustfs.stub
+++ b/stubs/rustfs.stub
@@ -13,18 +13,17 @@ rustfs:
         RUSTFS_CONSOLE_CORS_ALLOWED_ORIGINS: '*'
         RUSTFS_ACCESS_KEY: 'sail'
         RUSTFS_SECRET_KEY: 'password'
-        RUSTFS_LOG_LEVEL: 'info',
+        RUSTFS_LOG_LEVEL: 'info'
     volumes:
         - 'sail-rustfs:/data'
     networks:
         - sail
     healthcheck:
         test:
-        [
-          "CMD",
-          "sh", "-c",
-          "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/health"
-        ]
+          - "CMD"
+          - "sh"
+          - "-c"
+          - "curl -f http://127.0.0.1:9000/health && curl -f http://127.0.0.1:9001/health"
         interval: 30s
         timeout: 10s
         retries: 3


### PR DESCRIPTION
This PR corrects two minor syntax issues in the `rustfs.stub` file for Laravel Sail.

### 1. Correct Healthcheck YAML Syntax

The `healthcheck.test` command was defined using an invalid multi-line flow-style list (`[]`), which causes a YAML parsing error (e.g., "Unable to parse at line...") when Docker Compose tries to read the file after publishing the stub.

This commit 6d63366 updates the definition to use the standard YAML block-style list (using hyphens `-`), which is the correct syntax for this command.

**Before:**

``` yaml
    healthcheck:
      test:
      [
        "CMD",
        "sh", "-c",
        "curl -f [http://127.0.0.1:9000/health](http://127.0.0.1:9000/health) && curl -f [http://127.0.0.1:9001/health](http://127.0.0.1:9001/health)"
      ]
```

**After:**

``` yaml
    healthcheck:
      test:
        - "CMD"
        - "sh"
        - "-c"
        - "curl -f [http://127.0.0.1:9000/health](http://127.0.0.1:9000/health) && curl -f [http://127.0.0.1:9001/health](http://127.0.0.1:9001/health)"
```

### 2. Remove Trailing Comma

A trailing comma was removed from the RUSTFS_LOG_LEVEL environment
variable. While some YAML parsers may tolerate this, it's cleaner and
more consistent to remove it.

**Before:**

``` yaml
        RUSTFS_LOG_LEVEL: 'info',
```

**After:**

``` yaml
        RUSTFS_LOG_LEVEL: 'info'
```

### Evidence

<img width="632px" height="266px" alt="image" src="https://github.com/user-attachments/assets/6960b98a-c2bb-4b92-bbec-273e5c76ae8f" />

https://github.com/user-attachments/assets/0e5267b4-e600-456e-9872-948429bffb26

```bash
➜  docker -v
Docker version 28.3.2, build 578ccf6
```