### PR TITLE
Remove notice from MySQL service about the MYSQL_EXTRA_OPTIONS env not defined

### DIFF
--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -9,7 +9,7 @@ mysql:
         MYSQL_USER: '${DB_USERNAME}'
         MYSQL_PASSWORD: '${DB_PASSWORD}'
         MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS}'
+        MYSQL_EXTRA_OPTIONS: '${MYSQL_EXTRA_OPTIONS:-}'
     volumes:
         - 'sail-mysql:/var/lib/mysql'
         - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'


### PR DESCRIPTION
### Changed

- The `MYSQL_EXTRA_OPTIONS`  env was introduced in https://github.com/laravel/sail/pull/805, but was not made optional and since the variable doesn't exist in the default Laravel `.env.example` file ([source](https://github.com/laravel/laravel/blob/12.x/.env.example)), we get a warning when spinning up the service (see screenshot). This PR makes it optional by adding an empty default value.

---

<details>
<summary>Before/After</summary>

**Before:**

<img width="1866" height="1196" alt="image" src="https://github.com/user-attachments/assets/c9d56ffa-b7e7-4d34-a40a-974b67b7d4f5" />

**After:**

<img width="1358" height="1064" alt="image" src="https://github.com/user-attachments/assets/a9d20b70-eb52-4787-8dc7-58989cde4a3b" />

</details>