### PR TITLE
Replace mysql/mysql-server:8.0 with mysql:8.4

### DIFF
--- a/stubs/mysql.stub
+++ b/stubs/mysql.stub
@@ -1,5 +1,5 @@
 mysql:
-    image: 'mysql/mysql-server:8.0'
+    image: 'mysql:8.4'
     ports:
         - '${FORWARD_DB_PORT:-3306}:3306'
     environment:


### PR DESCRIPTION
This pull request updates the MySQL Docker image version used in the `mysql.stub` file. The new version aligns with the latest official MySQL release, which may provide improved stability, security, and compatibility.

Changed the Docker image from `mysql/mysql-server:8.0` to the official `mysql:8.4` image in `mysql.stub` to use the docker official image maintained by the [Docker Community and MySQL Team](https://hub.docker.com/_/mysql). 

Resolves https://github.com/laravel/sail/issues/829