### PR TITLE
[1.x] Fix error when `MYSQL_USER` in not set

### DIFF
--- a/database/mariadb/create-testing-database.sh
+++ b/database/mariadb/create-testing-database.sh
@@ -2,5 +2,10 @@
 
 /usr/bin/mariadb --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS testing;
+EOSQL
+
+if [ -n "$MYSQL_USER" ]; then
+/usr/bin/mariadb --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     GRANT ALL PRIVILEGES ON \`testing%\`.* TO '$MYSQL_USER'@'%';
 EOSQL
+fi

--- a/database/mysql/create-testing-database.sh
+++ b/database/mysql/create-testing-database.sh
@@ -2,5 +2,10 @@
 
 mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS testing;
+EOSQL
+
+if [ -n "$MYSQL_USER" ]; then
+mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     GRANT ALL PRIVILEGES ON \`testing%\`.* TO '$MYSQL_USER'@'%';
 EOSQL
+fi


### PR DESCRIPTION
When `DB_USERNAME` is set to `root` on the `.env` file, the container exits with the following error:

```
[ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
     Remove MYSQL_USER="root" and use one of the following to control the root user password:
     - MYSQL_ROOT_PASSWORD
     - MYSQL_ALLOW_EMPTY_PASSWORD
     - MYSQL_RANDOM_ROOT_PASSWORD
```

Following this guidance from error description and removing `MYSQL_USER` results in another error during initialization:

```
[Note] [Entrypoint]: /usr/local/bin/docker-entrypoint.sh: running /docker-entrypoint-initdb.d/10-create-testing-database.sh
     ERROR 1410 (42000) at line 2: You are not allowed to create a user with GRANT
```

This PR resolves the issue by conditionally executing the `GRANT` statement only when `MYSQL_USER` is defined and set.
