### PR TITLE
Fix volume path for PostgreSQL data storage

### DIFF
--- a/stubs/pgsql.stub
+++ b/stubs/pgsql.stub
@@ -8,7 +8,7 @@ pgsql:
         POSTGRES_USER: '${DB_USERNAME}'
         POSTGRES_PASSWORD: '${DB_PASSWORD:-secret}'
     volumes:
-        - 'sail-pgsql:/var/lib/postgresql/data'
+        - 'sail-pgsql:/var/lib/postgresql'
         - './vendor/laravel/sail/database/pgsql/create-testing-database.sql:/docker-entrypoint-initdb.d/10-create-testing-database.sql'
     networks:
         - sail


### PR DESCRIPTION
This PR fixes the postgres data volume for version 18+

> The defined VOLUME was changed in 18 and above to /var/lib/postgresql. 

https://hub.docker.com/_/postgres#pgdata