### PR TITLE
[1.x] Enable PHP 8.5 XDebug Support

### DIFF
--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get upgrade -y \
         php8.5-memcached \
         php8.5-pcov \
         php8.5-imagick \
-        #php8.5-xdebug \
+        php8.5-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \


### PR DESCRIPTION
This pull request makes a small change to the `runtimes/8.5/Dockerfile` by enabling the installation of the `php8.5-xdebug` extension, which was previously commented out due to the extension lacking PHP 8.5 runtime support. Added 16 Hours ago in 3.5.0 - https://github.com/xdebug/xdebug/releases/tag/3.5.0