### PR TITLE
Add justfile support

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarnkey.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarnkey.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /usr/share/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /usr/share/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     && curl -sS https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | tee /etc/apt/keyrings/pgdg.gpg >/dev/null \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && npx playwright install-deps \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && npx playwright install-deps \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \

--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -61,6 +61,7 @@ RUN apt-get update && apt-get upgrade -y \
     && npm install -g npm \
     && npm install -g pnpm \
     && npm install -g bun \
+    && npm install -g rust-just \
     && npx playwright install-deps \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor | tee /etc/apt/keyrings/yarn.gpg >/dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/yarn.gpg] https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \


### PR DESCRIPTION
[justfile](https://github.com/casey/just) became a very popular choice to define commonly reusable tasks into a simple format. Especially for development it can be used to define simple reusable workflows (initialize application, run specific queue workers, etc.). Within docker you normally want to run those commands within the container, meaning it makes sense to add it to the image, so that it can be run from within.

And it's a small one-line install and small package, so I though no harm :) 

Let me know what you think and nice day,
Jordan