### PR TITLE
[1.x] Fix AVIF support for GD

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.0-cli php8.0-dev \
+    && apt-get install -y libgd3 php8.0-cli php8.0-dev \
        php8.0-pgsql php8.0-sqlite3 php8.0-gd php8.0-imagick \
        php8.0-curl php8.0-memcached php8.0-mongodb \
        php8.0-imap php8.0-mysql php8.0-mbstring \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /usr/share/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/usr/share/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.1-cli php8.1-dev \
+    && apt-get install -y libgd3 php8.1-cli php8.1-dev \
        php8.1-pgsql php8.1-sqlite3 php8.1-gd php8.1-imagick \
        php8.1-curl php8.1-mongodb \
        php8.1-imap php8.1-mysql php8.1-mbstring \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.2-cli php8.2-dev \
+    && apt-get install -y libgd3 php8.2-cli php8.2-dev \
        php8.2-pgsql php8.2-sqlite3 php8.2-gd php8.2-imagick \
        php8.2-curl php8.2-mongodb \
        php8.2-imap php8.2-mysql php8.2-mbstring \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.3-cli php8.3-dev \
+    && apt-get install -y libgd3 php8.3-cli php8.3-dev \
        php8.3-pgsql php8.3-sqlite3 php8.3-gd \
        php8.3-curl php8.3-mongodb \
        php8.3-imap php8.3-mysql php8.3-mbstring \

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sS 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xb8dc7e53946656efbce4c1dd71daeaab4ad4cab6' | gpg --dearmor | tee /etc/apt/keyrings/ppa_ondrej_php.gpg > /dev/null \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
-    && apt-get install -y php8.4-cli php8.4-dev \
+    && apt-get install -y libgd3 php8.4-cli php8.4-dev \
        php8.4-pgsql php8.4-sqlite3 php8.4-gd \
        php8.4-curl php8.4-mongodb \
        php8.4-imap php8.4-mysql php8.4-mbstring \

--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && apt-get upgrade -y \
     && echo "deb [signed-by=/etc/apt/keyrings/ppa_ondrej_php.gpg] https://ppa.launchpadcontent.net/ondrej/php/ubuntu noble main" > /etc/apt/sources.list.d/ppa_ondrej_php.list \
     && apt-get update \
     && apt-get install -y \
+        libgd3 \
         php8.5-cli \
         php8.5-dev \
         php8.5-pgsql \


### PR DESCRIPTION
The current Docker app image lacks AVIF support because [Ubuntu's `libgd` AVIF support is disabled](https://bugs.launchpad.net/ubuntu/+source/libgd2/+bug/2031934).

```WARNING  imageavif(): AVIF image support has been disabled.```

This PR changes the Dockerfile so that it explicitly installs `libgd3` after Surý's PPA has been added so that it installs Surý's patched version which has AVIF support.
