### PR TITLE
Introduce APP_SHELL env to use custom shell (like zsh) for "sail shell" command

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -101,9 +101,9 @@ function display_help {
     echo
     echo "${YELLOW}Container CLI:${NC}"
     echo "  ${GREEN}sail shell${NC}        Start a shell session within the application container"
-    echo "  ${GREEN}sail bash${NC}         Alias for 'sail shell'"
+    echo "  ${GREEN}sail bash${NC}         Start a Bash session within the application container"
     echo "  ${GREEN}sail root-shell${NC}   Start a root shell session within the application container"
-    echo "  ${GREEN}sail root-bash${NC}    Alias for 'sail root-shell'"
+    echo "  ${GREEN}sail root-bash${NC}    Start a root Bash session within the application container"
     echo "  ${GREEN}sail tinker${NC}       Start a new Laravel Tinker session"
     echo
     echo "${YELLOW}Sharing:${NC}"
@@ -142,6 +142,7 @@ fi
 export APP_PORT=${APP_PORT:-80}
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
 export APP_USER=${APP_USER:-"sail"}
+export APP_SHELL=${APP_SHELL:-"bash"}
 export DB_PORT=${DB_PORT:-3306}
 export WWWUSER=${WWWUSER:-$UID}
 export WWWGROUP=${WWWGROUP:-$(id -g)}
@@ -520,8 +521,20 @@ elif [ "$1" == "psql" ]; then
         sail_is_not_running
     fi
 
+# Initiate a default shell within the application container...
+elif [ "$1" == "shell" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u "$APP_USER")
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "$APP_SHELL")
+    else
+        sail_is_not_running
+    fi
+
 # Initiate a Bash shell within the application container...
-elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
+elif [ "$1" == "bash" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
@@ -532,8 +545,20 @@ elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
         sail_is_not_running
     fi
 
+# Initiate a root user default shell within the application container...
+elif [ "$1" == "root-shell" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec -u root)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=("$APP_SERVICE" "$APP_SHELL")
+    else
+        sail_is_not_running
+    fi
+
 # Initiate a root user Bash shell within the application container...
-elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
+elif [ "$1" == "root-bash" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then


### PR DESCRIPTION
Laravel Sail currently hardcodes `bash` as the shell used when running `sail shell` and `sail bash`. This limits developers who prefer a different shell such as `zsh`, or who configure a non-bash default shell inside their application container.

Many developers use `zsh` as their primary shell due to its ecosystem of plugins and themes, commonly through frameworks such as [Oh My Zsh](https://ohmyz.sh/), which provide productivity features like better auto-completion, prompts, and tooling integration.

Additionally, `sail shell` and `sail bash` currently behave identically, which makes it difficult to distinguish between a configurable default shell and an explicit Bash session.

Sail already relies on environment-driven configuration, so allowing the default shell to be configured aligns well with its design philosophy.

#### What changed

* Added a new environment variable:

  * `APP_SHELL` (defaults to `bash`)
* Updated shell-related commands:

  * `sail shell` now starts the container using `$APP_SHELL`
  * `sail bash` always starts `bash`
  * `sail root-shell` uses `$APP_SHELL` as root
  * `sail root-bash` always starts `bash` as root
* Updated the CLI help output to clearly describe each command instead of treating `bash` commands as aliases.

#### Backward compatibility

* Fully backward compatible.
* When `APP_SHELL` is not set, it defaults to `bash`, preserving the current behavior.
* Existing scripts and workflows using `sail shell` or `sail bash` continue to work as before.

#### Example usage

```bash
export APP_SHELL=zsh
sail shell
```

This will start a `zsh` session inside the application container, assuming the shell is available.
