### PR TITLE
Replace MariaDB vendor paths with published paths in compose file

### DIFF
--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -37,10 +37,6 @@ class PublishCommand extends Command
 
         $composePath = $this->composePath();
 
-        $this->components->info(
-            "Replacing vendor mounted files with host paths in: [{$composePath}]"
-        );
-
         file_put_contents(
             $composePath,
             str_replace(

--- a/src/Console/PublishCommand.php
+++ b/src/Console/PublishCommand.php
@@ -35,8 +35,14 @@ class PublishCommand extends Command
         $this->call('vendor:publish', ['--tag' => 'sail-docker']);
         $this->call('vendor:publish', ['--tag' => 'sail-database']);
 
+        $composePath = $this->composePath();
+
+        $this->components->info(
+            "Replacing vendor mounted files with host paths in: [{$composePath}]"
+        );
+
         file_put_contents(
-            $this->composePath(),
+            $composePath,
             str_replace(
                 [
                     './vendor/laravel/sail/runtimes/8.5',
@@ -45,6 +51,7 @@ class PublishCommand extends Command
                     './vendor/laravel/sail/runtimes/8.2',
                     './vendor/laravel/sail/runtimes/8.1',
                     './vendor/laravel/sail/runtimes/8.0',
+                    './vendor/laravel/sail/database/mariadb',
                     './vendor/laravel/sail/database/mysql',
                     './vendor/laravel/sail/database/pgsql'
                 ],
@@ -55,10 +62,11 @@ class PublishCommand extends Command
                     './docker/8.2',
                     './docker/8.1',
                     './docker/8.0',
+                    './docker/mariadb',
                     './docker/mysql',
                     './docker/pgsql'
                 ],
-                file_get_contents($this->composePath())
+                file_get_contents($composePath)
             )
         );
     }


### PR DESCRIPTION
This PR fixes an issue where `sail:publish` correctly publishes MariaDB files but does not update MariaDB volume paths in the compose file.

It also adds a log message to make it clear when the compose file is being modified.

Fixes: https://github.com/laravel/sail/issues/844
