### PR TITLE
Added Dragonfly as Redis alternative

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -86,6 +86,7 @@ function display_help {
     echo "  ${GREEN}sail mongodb${NC}   Start a Mongo Shell session within the 'mongodb' container"
     echo "  ${GREEN}sail redis${NC}     Start a Redis CLI session within the 'redis' container"
     echo "  ${GREEN}sail valkey${NC}    Start a Valkey CLI session within the 'valkey' container"
+    echo "  ${GREEN}sail dragonfly${NC} Start a dragonfly CLI session within the 'dragonfly' container"
     echo
     echo "${YELLOW}Debugging:${NC}"
     echo "  ${GREEN}sail debug ...${NC}          Run an Artisan command in debug mode"
@@ -576,6 +577,18 @@ elif [ "$1" == "valkey" ]; then
         ARGS+=(exec)
         [ ! -t 0 ] && ARGS+=(-T)
         ARGS+=(valkey valkey-cli)
+    else
+        sail_is_not_running
+    fi
+
+# Initiate a Dragonfly CLI terminal session within the "dragonfly" container...
+elif [ "$1" == "dragonfly" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        ARGS+=(exec)
+        [ ! -t 0 ] && ARGS+=(-T)
+        ARGS+=(dragonfly redis-cli)
     else
         sail_is_not_running
     fi

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -31,6 +31,7 @@ trait InteractsWithDockerComposeServices
         'mongodb',
         'redis',
         'valkey',
+        'dragonfly',
         'memcached',
         'meilisearch',
         'typesense',
@@ -108,7 +109,7 @@ trait InteractsWithDockerComposeServices
         // Merge volumes...
         collect($services)
             ->filter(function ($service) {
-                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'mongodb', 'redis', 'valkey', 'meilisearch', 'typesense', 'minio', 'rustfs', 'rabbitmq']);
+                return in_array($service, ['mysql', 'pgsql', 'mariadb', 'mongodb', 'redis', 'valkey', 'dragonfly', 'meilisearch', 'typesense', 'minio', 'rustfs', 'rabbitmq']);
             })->filter(function ($service) use ($compose) {
                 return ! array_key_exists($service, $compose['volumes'] ?? []);
             })->each(function ($service) use (&$compose) {
@@ -181,6 +182,10 @@ trait InteractsWithDockerComposeServices
 
         if (in_array('valkey',$services)){
             $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=valkey', $environment);
+        }
+
+        if (in_array('dragonfly',$services)){
+            $environment = str_replace('REDIS_HOST=127.0.0.1', 'REDIS_HOST=dragonfly', $environment);
         }
 
         if (in_array('mongodb', $services)) {

--- a/stubs/dragonfly.stub
+++ b/stubs/dragonfly.stub
@@ -1,0 +1,12 @@
+dragonfly:
+    image: 'docker.dragonflydb.io/dragonflydb/dragonfly'
+    ports:
+        - '${FORWARD_VALKEY_PORT:-6379}:6379'
+    volumes:
+        - 'sail-dragonfly:/data'
+    networks:
+        - sail
+    healthcheck:
+        test: ["CMD", "redis-cli", "ping"]
+        retries: 3
+        timeout: 5s


### PR DESCRIPTION
Just like Valkey, DragonflyDB has become one of the most common Redis alternatives. It is built from scratch in C++ around a shared-nothing, multi-threaded architecture and exposes the same RESP protocol, requiring no application code changes.

Independent benchmarks from [centminmod/redis-comparison-benchmarks](https://github.com/centminmod/redis-comparison-benchmarks) — run on a 4 vCPU host using `memtier_benchmark` alongside Redis and Valkey — serve as a reference point for its throughput characteristics on multi-core hardware.
