### PR TITLE
Detect Windows non-WSL shells and guide users to WSL (fixes laravel/sail#850)

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -6,6 +6,15 @@ UNAMEOUT="$(uname -s)"
 case "${UNAMEOUT}" in
     Linux*)             MACHINE=linux;;
     Darwin*)            MACHINE=mac;;
+    MINGW*|MSYS*|CYGWIN*)
+        echo "Sail must be run from within WSL2, not from ${UNAMEOUT}." >&2
+        echo "" >&2
+        echo "Please open a WSL terminal and run Sail from there:" >&2
+        echo "  wsl" >&2
+        echo "  cd /mnt/c/path/to/your/project" >&2
+        echo "  ./vendor/bin/sail up" >&2
+
+        exit 1;;
     *)                  MACHINE="UNKNOWN"
 esac
 

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -290,6 +290,13 @@ trait InteractsWithDockerComposeServices
      */
     protected function prepareInstallation($services)
     {
+        // Skip pulling and building on Windows as the sail script requires WSL...
+        if ('\\' === DIRECTORY_SEPARATOR) {
+            $this->components->warn('Please run [./vendor/bin/sail up] from within WSL to complete the installation.');
+
+            return;
+        }
+
         // Ensure docker is installed...
         if ($this->runCommands(['docker info > /dev/null 2>&1']) !== 0) {
             return;


### PR DESCRIPTION
## Summary

Fixes laravel/sail#850 — Laravel Sail installation fails on Windows when running from Git Bash or native Windows PHP, giving unhelpful error messages.

## Steps to Reproduce

1. Install Laravel Sail on a Windows machine
2. Run `php artisan sail:install --with=mysql` from Windows PHP (not WSL)
3. Observe "The system cannot find the path specified" errors
4. Alternatively, run `./vendor/bin/sail up` from Git Bash (MINGW/MSYS) — get generic "Unsupported operating system" error

## Before (Bug)

Two failure modes:
1. **Git Bash**: `bin/sail` OS detection doesn't handle MINGW/MSYS/Cygwin — gives generic "Unsupported operating system" error with no guidance
2. **Windows PHP**: `prepareInstallation()` runs Unix shell commands (`./vendor/bin/sail pull`, `/dev/null`) that fail on Windows with "The system cannot find the path specified"

## After (Fix)

1. **Git Bash**: Clear, actionable message directing users to WSL2:
   ```
   Sail must be run from within WSL2, not from MINGW64_NT-10.0-26200.
   Please open a WSL terminal and run Sail from there:
     wsl
     cd /mnt/c/path/to/your/project
     ./vendor/bin/sail up
   ```
2. **Windows PHP**: `prepareInstallation()` detects Windows and skips Unix-only commands, showing a warning: "Please run [./vendor/bin/sail up] from within WSL to complete the installation."

## Root Cause

Sail assumes a Unix environment throughout. The `bin/sail` script doesn't recognize MINGW/MSYS/Cygwin as Windows environments. The `prepareInstallation()` PHP method runs Unix shell commands unconditionally.

## The Fix

- **`bin/sail`** — Added MINGW/MSYS/Cygwin case detection with clear WSL guidance message
- **`src/Console/Concerns/InteractsWithDockerComposeServices.php`** — `prepareInstallation()` checks `DIRECTORY_SEPARATOR` and skips Unix commands on Windows, showing a WSL warning

## Breaking Changes

None.

## Files Changed

- `bin/sail` — Added MINGW/MSYS/Cygwin detection with WSL guidance (+9 lines)
- `src/Console/Concerns/InteractsWithDockerComposeServices.php` — Windows detection in `prepareInstallation()` (+7 lines)

## Test Results

| Test | Result |
|------|--------|
| `./vendor/bin/sail up` from Git Bash | Shows helpful WSL guidance |
| `php artisan sail:install --with=mysql` from Windows PHP | Completes without errors, shows WSL warning |
| `./vendor/bin/sail up -d` from WSL | No regression |
| Full sail up/down/test cycle in WSL | All passing |