### PR TITLE
Conditionally wrap pest with xvfb-run when available

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -329,7 +329,7 @@ elif [ "$1" == "pest" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" php vendor/bin/pest)
+        ARGS+=("$APP_SERVICE" xvfb-run php vendor/bin/pest)
     else
         sail_is_not_running
     fi

--- a/bin/sail
+++ b/bin/sail
@@ -329,7 +329,7 @@ elif [ "$1" == "pest" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
-        if "${DOCKER_COMPOSE[@]}" exec -T "$APP_SERVICE" command -v xvfb-run &> /dev/null; then
+        if "${COMPOSE_CMD[@]}" exec -T "$APP_SERVICE" command -v xvfb-run &> /dev/null; then
             ARGS+=("$APP_SERVICE" xvfb-run php vendor/bin/pest)
         else
             ARGS+=("$APP_SERVICE" php vendor/bin/pest)

--- a/bin/sail
+++ b/bin/sail
@@ -329,7 +329,11 @@ elif [ "$1" == "pest" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" xvfb-run php vendor/bin/pest)
+        if "${DOCKER_COMPOSE[@]}" exec -T "$APP_SERVICE" command -v xvfb-run &> /dev/null; then
+            ARGS+=("$APP_SERVICE" xvfb-run php vendor/bin/pest)
+        else
+            ARGS+=("$APP_SERVICE" php vendor/bin/pest)
+        fi
     else
         sail_is_not_running
     fi


### PR DESCRIPTION
## Summary

Fixes laravel/sail#815 - Pest v4 browser tests fail in headed mode inside Sail containers with "XServer not running" error because the `pest` command lacks a virtual display server.

This PR wraps the `pest` command with `xvfb-run` only when `xvfb-run` is available in the container. Stock Sail containers that have not run `npx playwright install-deps` do not have `xvfb-run` installed, so unconditionally wrapping the command would break `sail pest` for those users.

## Steps to Reproduce

1. Set up a Laravel project using Sail with Pest v4 and `pest-plugin-browser`
2. Write a browser test that uses headed mode (e.g., `$page = visit('/')->debug()`)
3. Run `sail pest tests/Browser`
4. Observe Playwright error: "XServer not running"

## Before (Bug)

```
Target page, context or browser has been closed
Browser logs:
Looks like you launched a headed browser without having a XServer running.
Set either 'headless: true' or use 'xvfb-run'
```

PR #812 added Playwright support to Sail (including `npx playwright install-deps` which installs `xvfb`), but the `sail pest` command runs Pest directly without wrapping it in a virtual display. Headed Playwright tests require an X display server.

## After (Fix)

Browser tests run successfully inside the container. `xvfb-run` provides a virtual framebuffer that enables headed Playwright tests to work transparently. Non-browser Pest tests are unaffected (`xvfb-run` is transparent for tests that do not use a display).

## The Fix

Conditionally wraps the pest command with `xvfb-run` only when it is available in the container:

```diff
-ARGS+=("$APP_SERVICE" php vendor/bin/pest)
+if "${COMPOSE_CMD[@]}" exec -T "$APP_SERVICE" command -v xvfb-run &> /dev/null; then
+    ARGS+=("$APP_SERVICE" xvfb-run php vendor/bin/pest)
+else
+    ARGS+=("$APP_SERVICE" php vendor/bin/pest)
+fi
```

This ensures:
- Containers with Playwright/xvfb installed get the `xvfb-run` wrapper for headed browser tests
- Stock containers without xvfb continue to work as before

## Breaking Changes

None. The check is backward-compatible with all Sail containers.

## Files Changed

- `bin/sail` - Conditionally wrap pest command with `xvfb-run` when available