### PR TITLE
introduce new SAIL_DOCKER_BINARY env for podman support

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -153,6 +153,7 @@ export SAIL_SHARE_SERVER_PORT=${SAIL_SHARE_SERVER_PORT:-8080}
 export SAIL_SHARE_SUBDOMAIN=${SAIL_SHARE_SUBDOMAIN:-""}
 export SAIL_SHARE_DOMAIN=${SAIL_SHARE_DOMAIN:-"$SAIL_SHARE_SERVER_HOST"}
 export SAIL_SHARE_SERVER=${SAIL_SHARE_SERVER:-""}
+export SAIL_DOCKER_BINARY=${SAIL_DOCKER_BINARY:-"docker"}
 
 # Function that outputs Sail is not running...
 function sail_is_not_running {
@@ -164,10 +165,10 @@ function sail_is_not_running {
 }
 
 # Define Docker Compose command prefix...
-if docker compose &> /dev/null; then
-    DOCKER_COMPOSE=(docker compose)
+if ${SAIL_DOCKER_BINARY} compose &> /dev/null; then
+    COMPOSE_CMD=(${SAIL_DOCKER_BINARY} compose)
 else
-    DOCKER_COMPOSE=(docker-compose)
+    COMPOSE_CMD=(${SAIL_DOCKER_BINARY}-compose)
 fi
 
 if [ -n "$SAIL_FILES" ]; then
@@ -176,7 +177,7 @@ if [ -n "$SAIL_FILES" ]; then
 
     for FILE in "${SAIL_FILES[@]}"; do
         if [ -f "$FILE" ]; then
-            DOCKER_COMPOSE+=(-f "$FILE")
+            COMPOSE_CMD+=(-f "$FILE")
         else
             echo "${BOLD}Unable to find Docker Compose file: '${FILE}'${NC}" >&2
 
@@ -189,20 +190,20 @@ EXEC="yes"
 
 if [ -z "$SAIL_SKIP_CHECKS" ]; then
     # Ensure that Docker is running...
-    if ! docker info > /dev/null 2>&1; then
-        echo "${BOLD}Docker is not running.${NC}" >&2
+    if ! ${SAIL_DOCKER_BINARY} info > /dev/null 2>&1; then
+        echo "${BOLD}Docker or Podman is not running.${NC}" >&2
 
         exit 1
     fi
 
     # Determine if Sail is currently up...
-    if "${DOCKER_COMPOSE[@]}" ps "$APP_SERVICE" 2>&1 | grep 'Exit\|exited'; then
+    if "${COMPOSE_CMD[@]}" ps "$APP_SERVICE" 2>&1 | grep 'Exit\|exited'; then
         echo "${BOLD}Shutting down old Sail processes...${NC}" >&2
 
-        "${DOCKER_COMPOSE[@]}" down > /dev/null 2>&1
+        "${COMPOSE_CMD[@]}" down > /dev/null 2>&1
 
         EXEC="no"
-    elif [ -z "$("${DOCKER_COMPOSE[@]}" ps -q)" ]; then
+    elif [ -z "$("${COMPOSE_CMD[@]}" ps -q)" ]; then
         EXEC="no"
     fi
 fi
@@ -256,7 +257,7 @@ elif [ "$1" == "docker-compose" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
-        ARGS+=("$APP_SERVICE" "${DOCKER_COMPOSE[@]}")
+        ARGS+=("$APP_SERVICE" "${COMPOSE_CMD[@]}")
     else
         sail_is_not_running
     fi
@@ -585,7 +586,7 @@ elif [ "$1" == "share" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
-        docker run --init --rm --add-host=host.docker.internal:host-gateway -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+        ${SAIL_DOCKER_BINARY} run --init --rm --add-host=host.docker.internal:host-gateway -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \
@@ -629,4 +630,4 @@ elif [ "$1" == "open" ]; then
 fi
 
 # Run Docker Compose with the defined arguments...
-"${DOCKER_COMPOSE[@]}" "${ARGS[@]}" "$@"
+"${COMPOSE_CMD[@]}" "${ARGS[@]}" "$@"


### PR DESCRIPTION
This is another try to add support for podman. See #83 

In 2021 there was no plan to add support for podman. 5 years later I still think this should be added. The license changes on Docker Desktop made a lot of users switch to podman.

The changes are minimal and it does not break anything when using docker.
You just have to set this environment variable:

```
SAIL_DOCKER_BINARY=podman
```

This also allows to set additional options. For example setting the log-level is useful for debugging:

```
SAIL_DOCKER_BINARY="docker --log-level debug"
```