### PR TITLE
Clear config cache after modifying .env in sail:install

### DIFF
--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -54,6 +54,10 @@ class InstallCommand extends Command
         $this->replaceEnvVariables($services);
         $this->configurePhpUnit();
 
+        if (file_exists($this->laravel->getCachedConfigPath())) {
+            $this->call('config:clear');
+        }
+
         if ($this->option('devcontainer')) {
             $this->installDevContainer();
         }


### PR DESCRIPTION
Fixes #853

## Summary

`sail:install` modifies `.env` (database credentials, etc.) but doesn't clear the config cache. When a cached config exists, Laravel reads stale database credentials from `bootstrap/cache/config.php` instead of the updated `.env`, causing "Access denied" errors on the first `sail artisan migrate`.

### The Bug

```bash
composer create-project laravel/laravel myapp
cd myapp
composer require laravel/sail --dev
php artisan sail:install        # modifies .env with DB credentials
./vendor/bin/sail up -d
./vendor/bin/sail artisan migrate

# SQLSTATE[HY000] [1044] Access denied for user 'sail'@'%'
```

Users must manually run `sail artisan config:clear` to fix it.

### The Fix

Clear the config cache after `.env` is modified, but only if a cached config file exists:

```php
if (file_exists($this->laravel->getCachedConfigPath())) {
    $this->call('config:clear');
}
```

### Changes

- `src/Console/InstallCommand.php` — Clear config cache after env changes