### PR TITLE
Forward AI agent env vars into Docker containers

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -164,6 +164,34 @@ function sail_is_not_running {
     exit 1
 }
 
+# AI agent environment variables to forward into containers...
+AGENT_ENV_VARS=(
+    AI_AGENT
+    CLAUDECODE
+    CLAUDE_CODE
+    CURSOR_TRACE_ID
+    CURSOR_AGENT
+    GEMINI_CLI
+    CODEX_SANDBOX
+    CODEX_CI
+    CODEX_THREAD_ID
+    AUGMENT_AGENT
+    OPENCODE_CLIENT
+    OPENCODE
+    AMP_CURRENT_THREAD_ID
+    REPL_ID
+    ANTIGRAVITY_AGENT
+    COPILOT_MODEL
+)
+
+function forward_agent_env() {
+    for VAR in "${AGENT_ENV_VARS[@]}"; do
+        if [ -n "${!VAR:-}" ]; then
+            ARGS+=(-e "${VAR}=${!VAR}")
+        fi
+    done
+}
+
 # Define Docker Compose command prefix...
 if ${SAIL_DOCKER_BINARY} compose &> /dev/null; then
     COMPOSE_CMD=(${SAIL_DOCKER_BINARY} compose)
@@ -217,6 +245,7 @@ if [ "$1" == "php" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" "php")
     else
         sail_is_not_running
@@ -231,6 +260,7 @@ elif [ "$1" == "bin" ]; then
         shift 1
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" ./vendor/bin/"$CMD")
     else
         sail_is_not_running
@@ -245,6 +275,7 @@ elif [ "$1" == "run" ]; then
         shift 1
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" "$CMD")
     else
         sail_is_not_running
@@ -257,6 +288,7 @@ elif [ "$1" == "docker-compose" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" "${COMPOSE_CMD[@]}")
     else
         sail_is_not_running
@@ -269,6 +301,7 @@ elif [ "$1" == "composer" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" "composer")
     else
         sail_is_not_running
@@ -281,6 +314,7 @@ elif [ "$1" == "artisan" ] || [ "$1" == "art" ] || [ "$1" == "a" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php artisan)
     else
         sail_is_not_running
@@ -293,6 +327,7 @@ elif [ "$1" == "debug" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER" -e XDEBUG_TRIGGER=1)
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php artisan)
     else
         sail_is_not_running
@@ -305,6 +340,7 @@ elif [ "$1" == "test" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php artisan test)
     else
         sail_is_not_running
@@ -317,6 +353,7 @@ elif [ "$1" == "phpunit" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php vendor/bin/phpunit)
     else
         sail_is_not_running
@@ -329,6 +366,7 @@ elif [ "$1" == "pest" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php vendor/bin/pest)
     else
         sail_is_not_running
@@ -341,6 +379,7 @@ elif [ "$1" == "pint" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php vendor/bin/pint)
     else
         sail_is_not_running
@@ -353,6 +392,7 @@ elif [ "$1" == "dusk" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk)
@@ -367,6 +407,7 @@ elif [ "$1" == "dusk:fails" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=(-e "APP_URL=http://${APP_SERVICE}")
         ARGS+=(-e "DUSK_DRIVER_URL=http://selenium:4444/wd/hub")
         ARGS+=("$APP_SERVICE" php artisan dusk:fails)
@@ -381,6 +422,7 @@ elif [ "$1" == "tinker" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" php artisan tinker)
     else
         sail_is_not_running
@@ -393,6 +435,7 @@ elif [ "$1" == "node" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" node)
     else
         sail_is_not_running
@@ -405,6 +448,7 @@ elif [ "$1" == "npm" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" npm)
     else
         sail_is_not_running
@@ -417,6 +461,7 @@ elif [ "$1" == "npx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" npx)
     else
         sail_is_not_running
@@ -429,6 +474,7 @@ elif [ "$1" == "pnpm" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" pnpm)
     else
         sail_is_not_running
@@ -441,6 +487,7 @@ elif [ "$1" == "pnpx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" pnpx)
     else
         sail_is_not_running
@@ -453,6 +500,7 @@ elif [ "$1" == "yarn" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" yarn)
     else
         sail_is_not_running
@@ -465,6 +513,7 @@ elif [ "$1" == "bun" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" bun)
     else
         sail_is_not_running
@@ -477,6 +526,7 @@ elif [ "$1" == "bunx" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" bunx)
     else
         sail_is_not_running
@@ -528,6 +578,7 @@ elif [ "$1" == "shell" ] || [ "$1" == "bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u "$APP_USER")
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" bash)
     else
         sail_is_not_running
@@ -540,6 +591,7 @@ elif [ "$1" == "root-shell" ] || [ "$1" == "root-bash" ]; then
     if [ "$EXEC" == "yes" ]; then
         ARGS+=(exec -u root)
         [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
         ARGS+=("$APP_SERVICE" bash)
     else
         sail_is_not_running


### PR DESCRIPTION
AI coding agents (Claude Code, Cursor, Gemini CLI, Codex, etc.) set environment variables on the host to signal their presence. PHP packages like `nunomaduro/pao` and `pushpak1300/agent-detector` read these to detect agents and optimize output. When commands run inside Docker via `sail artisan`, `sail test`, etc., host env vars aren't forwarded — breaking agent detection entirely.

### Usage

```bash
# Agent env vars are now automatically forwarded when set
CLAUDECODE=1 sail artisan test
# Inside the container, CLAUDECODE=1 is available
```