### PR TITLE
fix: use docker compose directly during installation instead of sail script

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -295,15 +295,39 @@ trait InteractsWithDockerComposeServices
             return;
         }
 
+        // Ensure the WWWGROUP environment variable is set for the Compose build...
+        if (empty(getenv('WWWGROUP'))) {
+            putenv('WWWGROUP='.(function_exists('posix_getgid') ? posix_getgid() : 1000));
+        }
+
+        $composeCmd = $this->dockerComposeCommand();
+        $composePath = escapeshellarg($this->composePath());
+
         if (count($services) > 0) {
             $this->runCommands([
-                './vendor/bin/sail pull '.implode(' ', $services),
+                $composeCmd.' -f '.$composePath.' pull '.implode(' ', $services),
             ]);
         }
 
         $this->runCommands([
-            './vendor/bin/sail build',
+            $composeCmd.' -f '.$composePath.' build',
         ]);
+    }
+
+    /**
+     * Get the appropriate Docker Compose command.
+     *
+     * @return string
+     */
+    protected function dockerComposeCommand()
+    {
+        $docker = env('SAIL_DOCKER_BINARY', 'docker');
+
+        if ($this->runCommands([$docker.' compose > /dev/null 2>&1']) === 0) {
+            return $docker.' compose';
+        }
+
+        return $docker.'-compose';
     }
 
     /**

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -290,17 +290,19 @@ trait InteractsWithDockerComposeServices
      */
     protected function prepareInstallation($services)
     {
+        $docker = env('SAIL_DOCKER_BINARY', 'docker');
+
         // Ensure docker is installed...
-        if ($this->runCommands(['docker info > /dev/null 2>&1']) !== 0) {
+        if ((new Process([$docker, 'info']))->run() !== 0) {
             return;
         }
 
         // Ensure the WWWGROUP environment variable is set for the Compose build...
-        if (empty(getenv('WWWGROUP'))) {
+        if (getenv('WWWGROUP') === false) {
             putenv('WWWGROUP='.(function_exists('posix_getgid') ? posix_getgid() : 1000));
         }
 
-        $composeCmd = $this->dockerComposeCommand();
+        $composeCmd = $this->dockerComposeCommand($docker);
         $composePath = escapeshellarg($this->composePath());
 
         if (count($services) > 0) {
@@ -317,17 +319,18 @@ trait InteractsWithDockerComposeServices
     /**
      * Get the appropriate Docker Compose command.
      *
+     * @param  string  $docker
      * @return string
      */
-    protected function dockerComposeCommand()
+    protected function dockerComposeCommand($docker = 'docker')
     {
-        $docker = env('SAIL_DOCKER_BINARY', 'docker');
-
-        if ($this->runCommands([$docker.' compose > /dev/null 2>&1']) === 0) {
-            return $docker.' compose';
+        // Check for Docker Compose V2 (docker compose plugin)...
+        if ((new Process([$docker, 'compose', 'version']))->run() === 0) {
+            return escapeshellarg($docker).' compose';
         }
 
-        return $docker.'-compose';
+        // Fall back to Docker Compose V1 (docker-compose standalone)...
+        return escapeshellarg($docker.'-compose');
     }
 
     /**


### PR DESCRIPTION
## Summary
  - Fixes #850
  - Replaces `./vendor/bin/sail pull` and `./vendor/bin/sail build` calls in
    `prepareInstallation()` with direct `docker compose` commands, removing 
    the dependency on bash being available during `sail:install` and `sail:add`                                                                                                                                    
  - Adds a `dockerComposeCommand()` method that detects Docker Compose V2      
    (`docker compose`) or falls back to V1 (`docker-compose`), respecting                                                                                                                                          
    the `SAIL_DOCKER_BINARY` env var for Podman support                                                                                                                                                            
  - Ensures `WWWGROUP` is set in the environment before building, since the
    Dockerfile requires it as a build arg                                                                                                                                                                          
                                         
  ## Test plan                                                                                                                                                                                                     
  - [ ] Run `php artisan sail:install` on macOS/Linux and verify images are
        pulled and built correctly                                                                                                                                                                                 
  - [ ] Run `php artisan sail:add` and verify it works with the new compose
        command detection                                                  
  - [ ] Verify on Windows (without WSL bash) that the install command no
        longer fails with "path not found" 