### PR TITLE
Add missing AI agent env vars for Copilot CLI and Pi

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -182,6 +182,8 @@ AGENT_ENV_VARS=(
     REPL_ID
     ANTIGRAVITY_AGENT
     COPILOT_MODEL
+    COPILOT_CLI
+    PI_CODING_AGENT
 )
 
 function forward_agent_env() {


### PR DESCRIPTION
PR #862 introduced AI agent env var forwarding but missed two env vars that `shipfastlabs/agent-detector` recognizes: `COPILOT_CLI` and `PI_CODING_AGENT`.