### PR TITLE
[1.x] Add PHP_EXTENSIONS build arg to install additional PHP extensions

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -75,6 +76,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.0-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.0
 

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -75,6 +76,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.1-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.1
 

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -72,6 +73,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.2-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.2
 

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -72,6 +73,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.3-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.3
 

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -72,6 +73,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.4-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.4
 

--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -6,6 +6,7 @@ ARG WWWGROUP
 ARG NODE_VERSION=24
 ARG MYSQL_CLIENT="mysql-client"
 ARG POSTGRES_VERSION=18
+ARG PHP_EXTENSIONS=""
 
 WORKDIR /var/www/html
 
@@ -72,6 +73,14 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN if [ -n "$PHP_EXTENSIONS" ]; then \
+    apt-get update \
+    && apt-get install -y $(for ext in $PHP_EXTENSIONS; do echo "php8.5-$ext"; done) \
+    && apt-get -y autoremove \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
+fi
 
 RUN setcap "cap_net_bind_service=+ep" /usr/bin/php8.5
 


### PR DESCRIPTION
Adds an optional `PHP_EXTENSIONS` build argument to every runtime so users can install additional PHP extensions without having to publish and hand-edit the `Dockerfile`.

### Why

Sail ships a curated set of extensions, which is great for most apps. But some common packages require an extension that isn't in that list. For example, `laravel-notification-channels/webpush` → `minishlink/web-push` → `web-token/jwt-library` → `spomky-labs/pki-framework`, which hard-requires `ext-gmp` (for VAPID / elliptic-curve crypto). Today the only way to add it is `sail:publish` and editing the `Dockerfile` by hand, which then has to be re-reconciled every time the upstream runtime changes.

This lets the extension list be declared in `docker-compose.yml` instead:

```yaml
services:
    laravel.test:
        build:
            context: ./vendor/laravel/sail/runtimes/8.5
            dockerfile: Dockerfile
            args:
                WWWGROUP: '${WWWGROUP}'
                PHP_EXTENSIONS: 'gmp imagick'
```

The value is a space-separated list of extension suffixes; each is installed as `php{version}-{ext}` from the same Ondřej PPA already used for the base extensions.

### Behaviour

- Defaults to `""` — when empty the new `RUN` is a no-op, so **existing builds are unchanged**.
- Applied consistently across all supported runtimes (8.0–8.5).
- Reuses the existing apt cleanup so no extra layer bloat beyond the requested extensions.

### Note on tests

This is an image-build change with no PHP surface to unit-test; correctness is exercised by the existing build workflow. Happy to adjust the approach (naming, docs) if you'd prefer it shaped differently.
