### PR TITLE
[1.x] Fix MongoDB failing to restart by persisting the configdb volume

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -113,6 +113,10 @@ trait InteractsWithDockerComposeServices
                 return ! array_key_exists($service, $compose['volumes'] ?? []);
             })->each(function ($service) use (&$compose) {
                 $compose['volumes']["sail-{$service}"] = ['driver' => 'local'];
+
+                if ($service === 'mongodb') {
+                    $compose['volumes']['sail-mongodb-config'] = ['driver' => 'local'];
+                }
             });
 
         // If the list of volumes is empty, we can remove it...

--- a/stubs/mongodb.stub
+++ b/stubs/mongodb.stub
@@ -5,6 +5,7 @@ mongodb:
         - MONGODB_INITDB_ROOT_PASSWORD=${MONGODB_PASSWORD:-}
     volumes:
         - 'sail-mongodb:/data/db'
+        - 'sail-mongodb-config:/data/configdb'
     ports:
         - '${FORWARD_MONGODB_PORT:-27017}:27017'
     networks:


### PR DESCRIPTION
Fixes #882

The mongodb/mongodb-atlas-local image stores the keyfile it generates on first boot in /data/configdb, but the stub only persisted /data/db, so after sail down the keyfile was gone and the service failed to restart with an "Unable to acquire security key[s]" error. Persisting a volume for /data/configdb keeps it across restarts.
