### PR TITLE
Make phpunit.xml DB_DATABASE replacement whitespace-tolerant

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -251,7 +251,7 @@ trait InteractsWithDockerComposeServices
 
         $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
         $phpunit = preg_replace(
-            '/(<!--\s*)?<env\s+name="DB_DATABASE"\s+value=":memory:"\s*\/>(\s*-->)?/',
+            '/(<!--[ \t]*)?<env[ \t]+name="DB_DATABASE"[ \t]+value=":memory:"[ \t]*\/>(?(1)[ \t]*-->)/',
             '<env name="DB_DATABASE" value="testing"/>',
             $phpunit
         );

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -250,11 +250,8 @@ trait InteractsWithDockerComposeServices
         $phpunit = file_get_contents($path);
 
         $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
-        $phpunit = str_replace(
-            [
-                '<!-- <env name="DB_DATABASE" value=":memory:"/> -->',
-                '<env name="DB_DATABASE" value=":memory:"/>',
-            ],
+        $phpunit = preg_replace(
+            '/(<!--\s*)?<env\s+name="DB_DATABASE"\s+value=":memory:"\s*\/>(\s*-->)?/',
             '<env name="DB_DATABASE" value="testing"/>',
             $phpunit
         );


### PR DESCRIPTION
Fixes #773

The `configurePhpUnit()` method replaces the `DB_DATABASE` line in
`phpunit.xml` using an exact literal `str_replace`. If the line differs
by even a single character (e.g. a space before the self-closing slash,
`value=":memory:" />`), the replacement silently fails and tests run
against `:memory:` on MySQL/MariaDB.

This PR swaps the literal match for a whitespace-tolerant regex covering
both the plain and commented-out forms. No behavior change for files in
the exact skeleton format.