### PR TITLE
Add regression tests for phpunit.xml DB_DATABASE replacement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /vendor
 composer.lock
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
             "Laravel\\Sail\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Laravel\\Sail\\Tests\\": "tests/"
+        }
+    },
     "extra": {
         "laravel": {
             "providers": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Sail Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -250,11 +250,8 @@ trait InteractsWithDockerComposeServices
         $phpunit = file_get_contents($path);
 
         $phpunit = preg_replace('/^.*DB_CONNECTION.*\n/m', '', $phpunit);
-        $phpunit = str_replace(
-            [
-                '<!-- <env name="DB_DATABASE" value=":memory:"/> -->',
-                '<env name="DB_DATABASE" value=":memory:"/>',
-            ],
+        $phpunit = preg_replace(
+            '/(<!--\s*)?<env\s+name="DB_DATABASE"\s+value=":memory:"\s*\/>(\s*-->)?/',
             '<env name="DB_DATABASE" value="testing"/>',
             $phpunit
         );

--- a/tests/ConfigurePhpUnitTest.php
+++ b/tests/ConfigurePhpUnitTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Laravel\Sail\Tests;
+
+use Laravel\Sail\Console\InstallCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
+use ReflectionMethod;
+
+class ConfigurePhpUnitTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        @unlink($this->app->basePath('phpunit.xml'));
+
+        parent::tearDown();
+    }
+
+    #[DataProvider('phpUnitDatabaseEnvLineProvider')]
+    public function test_it_replaces_the_in_memory_database_value_regardless_of_formatting($envLine)
+    {
+        file_put_contents($this->app->basePath('phpunit.xml'), <<<XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <phpunit>
+            <php>
+                <env name="DB_CONNECTION" value="sqlite"/>
+                {$envLine}
+            </php>
+        </phpunit>
+        XML);
+
+        $command = new InstallCommand();
+        $command->setLaravel($this->app);
+
+        $method = new ReflectionMethod($command, 'configurePhpUnit');
+        $method->setAccessible(true);
+        $method->invoke($command);
+
+        $contents = file_get_contents($this->app->basePath('phpunit.xml'));
+
+        $this->assertStringContainsString('<env name="DB_DATABASE" value="testing"/>', $contents);
+        $this->assertStringNotContainsString(':memory:', $contents);
+        $this->assertStringNotContainsString('DB_CONNECTION', $contents);
+    }
+
+    public static function phpUnitDatabaseEnvLineProvider()
+    {
+        return [
+            'default skeleton formatting' => [
+                '<env name="DB_DATABASE" value=":memory:"/>',
+            ],
+            'extra space before self-closing slash' => [
+                '<env name="DB_DATABASE" value=":memory:" />',
+            ],
+            'commented out variant' => [
+                '<!-- <env name="DB_DATABASE" value=":memory:"/> -->',
+            ],
+            'commented out variant with extra space' => [
+                '<!-- <env name="DB_DATABASE" value=":memory:" /> -->',
+            ],
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Laravel\Sail\Tests;
+
+use Laravel\Sail\SailServiceProvider;
+use Orchestra\Testbench\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    /**
+     * Get package providers.
+     *
+     * @param  \Illuminate\Foundation\Application  $app
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [SailServiceProvider::class];
+    }
+}


### PR DESCRIPTION
Depends on #885, which already fixes the underlying replacement logic in `configurePhpUnit()` (the exact literal `str_replace` failing silently on formatting drift, see #773).

This package has `orchestra/testbench` as a dev dependency but no `tests/` directory at all, so this adds the first test suite alongside coverage for that fix: four formatting variants of the `DB_DATABASE` env line (default skeleton, extra space before the self-closing slash, commented-out, commented-out with extra space), asserting the value actually flips to `testing`.

Once #885 merges, the source hunk in this PR becomes a no-op and this can be rebased down to just the test files.

## Test plan

- [x] `vendor/bin/phpunit tests/` passes locally, all 4 cases green
- [x] Confirmed the two whitespace-sensitive cases fail against `main` as-is (before #885 or this PR), proving the tests catch the real bug
- [x] `vendor/bin/phpstan analyse` clean on the changed file
