### PR TITLE
Fix APP_PORT export always overriding the compose file's own default

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -139,7 +139,11 @@ elif [ -f ./.env ]; then
 fi
 
 # Define environment variables...
-export APP_PORT=${APP_PORT:-80}
+# Only export APP_PORT if it's already set, otherwise an exported default
+# here would always beat the compose file's own ${APP_PORT:-80} default.
+if [ -n "$APP_PORT" ]; then
+    export APP_PORT
+fi
 export APP_SERVICE=${APP_SERVICE:-"laravel.test"}
 export APP_USER=${APP_USER:-"sail"}
 export DB_PORT=${DB_PORT:-3306}
@@ -644,7 +648,7 @@ elif [ "$1" == "share" ]; then
     shift 1
 
     if [ "$EXEC" == "yes" ]; then
-        ${SAIL_DOCKER_BINARY} run --init --rm --add-host=host.docker.internal:host-gateway -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"$APP_PORT" \
+        ${SAIL_DOCKER_BINARY} run --init --rm --add-host=host.docker.internal:host-gateway -p "$SAIL_SHARE_DASHBOARD":4040 -t beyondcodegmbh/expose-server:latest share http://host.docker.internal:"${APP_PORT:-80}" \
             --server-host="$SAIL_SHARE_SERVER_HOST" \
             --server-port="$SAIL_SHARE_SERVER_PORT" \
             --auth="$SAIL_SHARE_TOKEN" \


### PR DESCRIPTION
Fixes #827.

`bin/sail` unconditionally exports `APP_PORT` with a default of `80`:

```bash
export APP_PORT=${APP_PORT:-80}
```

Since it's exported, that value is always present in the environment `docker compose` sees. Docker Compose's own variable interpolation (`${APP_PORT:-80}` in a project's compose file) only falls back to its inline default when the variable is completely unset, an already-set environment variable always wins, no matter where that value came from. So a custom default set directly in a project's compose file (like `${APP_PORT:-84}` from #827) can never actually take effect.

Confirmed with `docker compose config` against a minimal compose file using `${APP_PORT:-84}:80`:

| scenario | resolved published port |
|---|---|
| no `.env`, nothing exported | `84` (compose file's own default) |
| `.env` has `APP_PORT=84` | `84` |
| shell has `APP_PORT=80` exported (today's `bin/sail` behavior) | `80`, compose file's own default silently ignored |

The fix only exports `APP_PORT` when it's actually set (via the environment or a sourced `.env`), so the compose file's own default is free to apply otherwise. No behavior change for the default case, the shipped compose stub already defaults to `${APP_PORT:-80}` itself.

One other spot, the `sail share` command, read `$APP_PORT` directly assuming it was always set. Updated it to use an inline `${APP_PORT:-80}` fallback so it isn't affected by `APP_PORT` now legitimately being unset.

## Test plan

Ran the actual `bin/sail` logic (`.env` sourcing plus the export change) against `docker compose config` for three scenarios:
- [x] Brand new project, no `.env` `APP_PORT` line at all: still resolves to `80`, matching current behavior
- [x] `.env` sets `APP_PORT=8080` explicitly: still resolves to `8080`
- [x] No `.env` override, compose file's own default customized to `84` (the reported case): now correctly resolves to `84` instead of being stuck at `80`
- [x] `bash -n bin/sail` and `shellcheck --severity=warning bin/sail`: no new warnings introduced
