### PR TITLE
Create APP_USER in container when it does not exist

### DIFF
--- a/runtimes/8.0/start-container
+++ b/runtimes/8.0/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.1/start-container
+++ b/runtimes/8.1/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.2/start-container
+++ b/runtimes/8.2/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.3/start-container
+++ b/runtimes/8.3/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.4/start-container
+++ b/runtimes/8.4/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/runtimes/8.5/start-container
+++ b/runtimes/8.5/start-container
@@ -9,6 +9,10 @@ if [ ! -z "$WWWUSER" ]; then
     usermod -u $WWWUSER sail
 fi
 
+if [ ! -z "$APP_USER" ] && ! id "$APP_USER" > /dev/null 2>&1; then
+    useradd -ms /bin/bash --no-user-group -g sail "$APP_USER"
+fi
+
 if [ ! -d /.composer ]; then
     mkdir /.composer
 fi

--- a/stubs/compose.stub
+++ b/stubs/compose.stub
@@ -14,6 +14,7 @@ services:
             - '${VITE_PORT:-5173}:${VITE_PORT:-5173}'
         environment:
             WWWUSER: '${WWWUSER}'
+            APP_USER: '${APP_USER:-sail}'
             LARAVEL_SAIL: 1
             XDEBUG_MODE: '${SAIL_XDEBUG_MODE:-off}'
             XDEBUG_CONFIG: '${SAIL_XDEBUG_CONFIG:-client_host=host.docker.internal}'


### PR DESCRIPTION
Fixes #799.

#785 added the `APP_USER` environment variable so that Sail commands run as a
custom user (`docker compose exec -u "$APP_USER"`). However, nothing actually
creates that user inside the container, so with the stock runtimes any value
other than `sail` breaks every command:

    unable to find user test: no matching entries in passwd file

This PR makes `start-container` create the user on startup when it does not
already exist, using the same approach as the existing `sail` user and sharing
the `sail` group so file permissions behave the same. The compose stub now also
passes `APP_USER` into the container, since `bin/sail` already exports it.

When `APP_USER` is unset or left at its default (`sail`), the script does
nothing, so existing projects are unaffected. I verified this by building the
8.4 runtime: with `APP_USER=test`, the user is created and
`docker compose exec -u test` works; without it, the container's passwd entries
are identical to before the change.