### PR TITLE
Enable dumpless upgrades for Meilisearch

### DIFF
--- a/src/Console/Concerns/InteractsWithDockerComposeServices.php
+++ b/src/Console/Concerns/InteractsWithDockerComposeServices.php
@@ -194,8 +194,9 @@ trait InteractsWithDockerComposeServices
 
         if (in_array('meilisearch', $services)) {
             $environment .= "\nSCOUT_DRIVER=meilisearch";
-            $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700\n";
-            $environment .= "\nMEILISEARCH_NO_ANALYTICS=false\n";
+            $environment .= "\nMEILISEARCH_HOST=http://meilisearch:7700";
+            $environment .= "\nMEILISEARCH_NO_ANALYTICS=false";
+            $environment .= "\nMEILISEARCH_UPGRADE_DB=true\n";
         }
 
         if (in_array('typesense', $services)) {

--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -4,6 +4,7 @@ meilisearch:
         - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
     environment:
         MEILI_NO_ANALYTICS: '${MEILISEARCH_NO_ANALYTICS:-false}'
+        MEILI_UPGRADE_DB: '${MEILISEARCH_UPGRADE_DB:-true}'
     volumes:
         - 'sail-meilisearch:/meili_data'
     networks:


### PR DESCRIPTION
If you docker pull a newer image of Meilisearch with a new version, the container will crash if a database already exists.

[Dumpless upgrades](https://www.meilisearch.com/docs/resources/migration/updating#updating-a-self-hosted-meilisearch-instance) have been [declared stable](https://github.com/orgs/meilisearch/discussions/804#discussioncomment-17751853) recently so add them to the meili stub to prevent Meilisearch from crashing when a newer image is pulled.