### PR TITLE
Add CPX command support

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -56,6 +56,10 @@ function display_help {
     echo "  ${GREEN}sail composer ...${NC}                       Run a Composer command"
     echo "  ${GREEN}sail composer require laravel/sanctum${NC}"
     echo
+    echo "${YELLOW}CPX Commands:${NC}"
+    echo "  ${GREEN}sail cpx ...${NC}                       Run a CPX command (requires PHP 8.2+)"
+    echo "  ${GREEN}sail cpx php-cs-fixer fix ./src${NC}"
+    echo
     echo "${YELLOW}Node Commands:${NC}"
     echo "  ${GREEN}sail node ...${NC}         Run a Node command"
     echo "  ${GREEN}sail node --version${NC}"
@@ -309,6 +313,34 @@ elif [ "$1" == "composer" ]; then
         [ ! -t 0 ] && ARGS+=(-T)
         forward_agent_env
         ARGS+=("$APP_SERVICE" "composer")
+    else
+        sail_is_not_running
+    fi
+
+# Proxy CPX commands to the "cpx" binary on the application container...
+elif [ "$1" == "cpx" ]; then
+    shift 1
+
+    if [ "$EXEC" == "yes" ]; then
+        # Determine the PHP version running in the container...
+        if ! PHP_VERSION=$("${COMPOSE_CMD[@]}" exec -u "$APP_USER" -T "$APP_SERVICE" php -r 'echo PHP_MAJOR_VERSION . "." . PHP_MINOR_VERSION;'); then
+            sail_is_not_running
+        fi
+
+        PHP_MAJOR="${PHP_VERSION%%.*}"
+        PHP_MINOR="${PHP_VERSION#*.}"
+
+        # Ensure cpx is supported on the current PHP version (requires PHP 8.2+)...
+        if [ "$PHP_MAJOR" -lt 8 ] || { [ "$PHP_MAJOR" -eq 8 ] && [ "$PHP_MINOR" -lt 2 ]; }; then
+            echo "${BOLD}cpx is not supported on PHP ${PHP_VERSION}. cpx requires PHP 8.2 or higher.${NC}" >&2
+
+            exit 1
+        fi
+
+        ARGS+=(exec -u "$APP_USER")
+        [ ! -t 0 ] && ARGS+=(-T)
+        forward_agent_env
+        ARGS+=("$APP_SERVICE" "cpx")
     else
         sail_is_not_running
     fi

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.2-imagick \
         php8.2-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^1.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.3-imagick \
         php8.3-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.4-imagick \
         php8.4-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \

--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -57,6 +57,8 @@ RUN apt-get update && apt-get upgrade -y \
         php8.5-imagick \
         php8.5-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
+    && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
+    && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
     && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
     && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \


### PR DESCRIPTION
Adds support for `cpx` command for running `vendor/bin/sail cpx <package-name> <command> [arguments]`.

Only adds support for PHP 8.2+ as that is what CPX currently supports, and properly shows error message when `cpx` is not supported.