### PR TITLE
Forward COLORTERM to Sail container commands

### DIFF
--- a/bin/sail
+++ b/bin/sail
@@ -721,5 +721,10 @@ elif [ "$1" == "open" ]; then
     fi
 fi
 
+# Forward the host terminal's color capability to container commands...
+if [ "${ARGS[0]:-}" == "exec" ] && [ -n "${COLORTERM:-}" ]; then
+    ARGS=(exec -e "COLORTERM=${COLORTERM}" "${ARGS[@]:1}")
+fi
+
 # Run Docker Compose with the defined arguments...
 "${COMPOSE_CMD[@]}" "${ARGS[@]}" "$@"


### PR DESCRIPTION
<!--
Please only send a pull request to branches which are currently supported: https://laravel.com/docs/releases#support-policy 

If you are unsure which branch your pull request should be sent to, please read: https://laravel.com/docs/contributions#which-branch

Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
I noticed when using the new multiplexed dev server command, that some of the text is unreadable - as it blends into the background. In particular the footer labels and inactive tab numbers.

From my understanding, this happens because the underlying library that multiplex uses, chalk, thinks we're using a 16 color terminal. 

Docker by default, sets `TERM=xterm` when allocating a pseudo-terminal. That combined with the fact that `COLORTERM` is missing, results in Chalk detecting only 16 color support.

The proposed fix is to forward the `COLORTERM` environment variable (when present on the host) to the docker container when running sail commands.

Before:
<img width="1928" height="1160" alt="screenshot-2026-09-10_15-50-48" src="https://github.com/user-attachments/assets/cec6dd18-aa2b-4f5d-8e19-83b617a2d01e" />

After:
<img width="1928" height="1160" alt="screenshot-2026-09-10_15-51-35" src="https://github.com/user-attachments/assets/e4c07c06-09ce-4225-8960-da87df44965a" />
