### PR TITLE
[1.x] Correctly pin NodeSource APT repo

### DIFF
--- a/runtimes/8.0/Dockerfile
+++ b/runtimes/8.0/Dockerfile
@@ -58,9 +58,7 @@ RUN apt-get update && apt-get upgrade -y \
         php8.0-imagick \
         php8.0-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g pnpm \

--- a/runtimes/8.1/Dockerfile
+++ b/runtimes/8.1/Dockerfile
@@ -58,9 +58,7 @@ RUN apt-get update && apt-get upgrade -y \
         php8.1-imagick \
         php8.1-xdebug \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm \
     && npm install -g pnpm \

--- a/runtimes/8.2/Dockerfile
+++ b/runtimes/8.2/Dockerfile
@@ -60,9 +60,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^1.0 \
     && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm pnpm bun corepack \
     && corepack enable \

--- a/runtimes/8.3/Dockerfile
+++ b/runtimes/8.3/Dockerfile
@@ -60,9 +60,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
     && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm pnpm bun corepack \
     && corepack enable \

--- a/runtimes/8.4/Dockerfile
+++ b/runtimes/8.4/Dockerfile
@@ -60,9 +60,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
     && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm pnpm bun corepack \
     && corepack enable \

--- a/runtimes/8.5/Dockerfile
+++ b/runtimes/8.5/Dockerfile
@@ -60,9 +60,7 @@ RUN apt-get update && apt-get upgrade -y \
     && curl -sLS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer \
     && COMPOSER_HOME=/usr/local/share/composer composer global require cpx/cpx:^2.0 \
     && ln -s /usr/local/share/composer/vendor/bin/cpx /usr/local/bin/cpx \
-    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_VERSION.x nodistro main" > /etc/apt/sources.list.d/nodesource.list \
-    && apt-get update \
+    && curl -fsSL https://deb.nodesource.com/setup_$NODE_VERSION.x | bash - \
     && apt-get install -y nodejs \
     && npm install -g npm pnpm bun corepack \
     && corepack enable \


### PR DESCRIPTION
When picking a sufficient old `$NODE_VERSION` building the images fails.

```
bash: /usr/bin/npm: No such file or directory
```

This is because NodeJS isn't pinned to the NodeSource APT repository and when the distro holds a newer version it is installed instead (v18 on Noble, v22 on Resolute). Ubuntu's `nodejs` package doesn't contain `bin/npm` because it's in a separate package.

This PR reverts the changes of #613. The NodeSource install scripts deprecation has been reverted and those scripts correctly pin the `nodejs` package to the NodeSource APT repo.